### PR TITLE
fix: honor panelTools from fusion.json in /fusion-setup TUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.7.4
+
+- The `fusion` tool no longer exposes `panel_tools`, `max_tool_calls`, `temperature`, or `max_completion_tokens` as parameters. The invoking model was using them to override the user's `/fusion-setup` choice (e.g. setting `max_tool_calls` to 25 over a configured 100). All such config is now user-only (session via `/fusion-setup`, or `fusion.json`); the tool takes only the prompt and the conversation-context controls.
+- Failed panels now carry their tool-loop usage (`turns`, `tool_calls`, `capped`) in `failed_models`, so diagnostics/session traces show how far a model got before returning empty (not just the error string).
+
 ## 0.7.3
 
 - When a panel model hits the tool-call limit (or the loop guard), it's now told via the system prompt to write its final answer from what it gathered — some models otherwise went silent when tools were removed, returning empty.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fusion",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fusion",
-      "version": "0.7.3",
+      "version": "0.7.4",
       "license": "MIT",
       "devDependencies": {
         "jiti": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fusion",
-  "version": "0.7.3",
+  "version": "0.7.4",
   "description": "Multi-model deliberation for pi, inspired by OpenRouter Fusion",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ import {
 	DEFAULT_MAX_TOOL_CALLS,
 	generateConfigExample,
 	loadConfig,
+	type FusionConfig,
 } from "./config.ts";
 import { buildRecentContextFromEntries, type FusionContextMode, normalizeContextTurns } from "./context.ts";
 import { resolveFusionModels, runFusion } from "./fusion.ts";
@@ -307,14 +308,18 @@ function buildInitialState(
 	ctx: ExtensionContext,
 	resolvedPanel: ModelWithDisplay[],
 	resolvedJudge: ModelWithDisplay,
+	configPanelTools?: FusionConfig["panelTools"],
 ): FusionSetupState {
 	const sessionState = restoreSessionState(ctx);
+	const configTools = typeof configPanelTools === "string" ? configPanelTools : undefined;
 	return {
 		selectedIds: sessionState?.selectedIds ?? new Set(resolvedPanel.map((m) => m.display)),
 		judgeId: sessionState?.judgeId ?? resolvedJudge.display,
 		enabled: normalizeMode(sessionState) === "forced",
 		mode: normalizeMode(sessionState),
-		panelTools: sessionState?.panelTools ?? "none",
+		panelTools: sessionState?.panelTools && sessionState.panelTools !== "none"
+			? sessionState.panelTools
+			: configTools ?? "none",
 		maxToolCalls: sessionState?.maxToolCalls ?? DEFAULT_MAX_TOOL_CALLS,
 		toolsConsented: sessionState?.toolsConsented ?? false,
 	};
@@ -556,6 +561,7 @@ export default function (pi: ExtensionAPI) {
 				ctx.ui.notify("No authed text models available.", "error");
 				return;
 			}
+			const config = loadConfig(ctx.cwd, ctx.isProjectTrusted());
 
 			const { panel, judge, warnings } = await resolveFusionModels(
 				ctx.cwd,
@@ -569,6 +575,7 @@ export default function (pi: ExtensionAPI) {
 				ctx,
 				panel.map((m) => ({ display: modelDisplay(m) })),
 				{ display: modelDisplay(judge) },
+				config.panelTools,
 			);
 
 			const state = await selectFusionSetup(ctx, available, initial);


### PR DESCRIPTION
## Problem

The `/fusion-setup` TUI always showed `Panel tools: none` even when `fusion.json` specified `"panelTools": "readonly"` or `"panelTools": "all"`.

## Root Cause

`buildInitialState` only checked session state for `panelTools`:
```ts
panelTools: sessionState?.panelTools ?? "none",
```

No session state (first TUI open) → always defaulted to `"none"`. Config was never consulted.

## Fix

Fallback chain is now: **session state → config → "none"**

- Load config in `/fusion-setup` handler
- Pass `config.panelTools` to `buildInitialState`
- Use as middle fallback before hardcoded default

## Changes

- `src/index.ts`: Add `configPanelTools` parameter to `buildInitialState`
- `src/index.ts`: Load config and pass to `buildInitialState` in `/fusion-setup` handler