### PR TITLE
fix: preserve extension statuses in fusion footer

### DIFF
--- a/.compound-engineering/config.local.example.yaml
+++ b/.compound-engineering/config.local.example.yaml
@@ -1,0 +1,63 @@
+# Compound Engineering -- local config
+# Copy to .compound-engineering/config.local.yaml in your project root.
+# All settings are optional. Invalid values fall through to defaults.
+
+# --- Work delegation (Codex) ---
+
+# work_delegate: codex           # codex | false (default: false)
+# work_delegate_consent: true    # true | false (default: false)
+# work_delegate_sandbox: yolo    # yolo | full-auto (default: yolo)
+# work_delegate_decision: auto   # auto | ask (default: auto)
+# work_delegate_model: gpt-5.4   # any valid codex model (omit to use ~/.codex/config.toml default)
+# work_delegate_effort: high     # minimal | low | medium | high | xhigh (omit to use ~/.codex/config.toml default)
+
+# --- Product pulse ---
+# Settings written by /ce-product-pulse first-run interview. Re-run the skill with
+# argument `setup` or `reconfigure` to edit interactively.
+
+# pulse_product_name: "Spiral"                          # used in report titles (no default)
+# pulse_lookback_default: 24h                           # 1h | 24h | 7d | 30d (default: 24h)
+# pulse_primary_event: "session_started"                # the event that means "user showed up"
+# pulse_value_event: "task_completed"                   # the event that means "user got value"
+# pulse_completion_events: "onboarded,first_purchase"   # comma-separated, 0-3 events
+# pulse_quality_scoring: false                          # true | false (default: false; AI products only)
+# pulse_quality_dimension: "answer accuracy"            # dimension scored 1-5 when pulse_quality_scoring is true
+# pulse_analytics_source: posthog                       # posthog | mixpanel | custom (no default)
+# pulse_tracing_source: sentry                          # sentry | datadog | custom (no default)
+# pulse_payments_source: stripe                         # stripe | custom (no default)
+# pulse_db_enabled: false                               # true | false (default: false; read-only DB if true)
+# pulse_metric_sources: "retention_d7=posthog,nps=delighted"  # strategy-metric -> source overrides; comma-separated 'metric=source' pairs; unlisted metrics fall back to pulse_analytics_source
+# pulse_pending_metrics: "retention_d7,nps"             # comma-separated strategy metrics awaiting instrumentation; render as 'no data'
+# pulse_excluded_metrics: "north_star"                  # comma-separated strategy metrics intentionally not in pulse
+
+# --- Output format ---
+# Per-skill output format default. Selects the exclusive format the artifact
+# is written in: `md` produces a markdown file, `html` produces a single
+# self-contained HTML file. The two are mutually exclusive -- there is no
+# sibling artifact. See DESIGN.md or your agent instructions to influence
+# HTML styling. Precedence: a format request in your prompt for that run wins
+# (e.g. "output:html" or "make it HTML"); a preference you established earlier
+# (in-session, saved to memory, or in your agent instructions) overrides these
+# keys (this config is the persisted fallback); pipeline contexts (e.g., LFG,
+# disable-model-invocation) always force `md`.
+
+# plan_output: html              # md | html (default: md)
+# brainstorm_output: html        # md | html (default: md)
+# ideate_output: md              # md | html (default: html -- ideation docs are human-facing, so HTML is the default; set md to opt out)
+
+# --- ce-plan scoping confirmation ---
+# By default /ce-plan pauses before research/plan-write to show a scoping
+# summary and wait for you to confirm scope. Set this to skip that wait: ce-plan
+# composes the summary for itself, records any inferred scope under an
+# Assumptions section, announces that it's proceeding, and keeps going. It skips
+# only that confirmation -- genuine blocking questions and the post-plan menu
+# still appear. Override per run with `confirm:auto` (skip) or `confirm:ask`
+# (force the gate on for one run).
+
+# plan_skip_scoping_confirm: true   # true | false (default: false)
+
+# --- ce-promote ---
+# Written automatically when you decline the Spiral setup offer in /ce-promote.
+# Suppresses that one-time setup nudge in this project. Remove the key to re-enable.
+
+# ce_promote_spiral_optout: true   # true | (absent) (default: absent -- offer once)

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 *.log
 .DS_Store
 *.tsbuildinfo
+.compound-engineering/*.local.yaml

--- a/docs/plans/2026-06-30-001-fix-footer-extension-statuses-plan.md
+++ b/docs/plans/2026-06-30-001-fix-footer-extension-statuses-plan.md
@@ -1,0 +1,138 @@
+---
+title: "fix: Preserve extension statuses in custom footer"
+date: "2026-06-30"
+type: "fix"
+artifact_contract: "ce-unified-plan/v1"
+artifact_readiness: "implementation-ready"
+execution: "code"
+product_contract_source: "ce-plan-bootstrap"
+origin: "https://github.com/synthetic-recon/pi-fusion/issues/10"
+---
+
+# fix: Preserve extension statuses in custom footer
+
+## Goal Capsule
+
+| Field | Value |
+|---|---|
+| Objective | Keep pi-fusion's custom footer while preserving status output registered by other Pi extensions. |
+| Source of truth | GitHub issue #10, installed Pi type declarations, and existing footer behavior in `src/index.ts`. |
+| Execution profile | Small behavior fix with unit coverage before final repo checks. |
+| Stop conditions | Stop if the installed Pi footer data API differs from the issue's reported surface or if preserving statuses requires changing Pi itself. |
+| Tail ownership | LFG owns implementation, review fixes, verification, commit, PR, and CI watch. |
+
+---
+
+## Product Contract
+
+### Summary
+
+pi-fusion currently replaces Pi's built-in footer when it renders fusion status, but the custom footer returns only pi-fusion's top and bottom lines.
+That hides status text from other extensions registered through Pi's status API, making extensions such as token-speed appear broken even when their commands still work.
+This fix preserves pi-fusion's footer content and appends other extension statuses when Pi exposes them.
+
+### Problem Frame
+
+The extension intentionally uses `ctx.ui.setFooter()` so it can show cwd, token/cost stats, model details, and fusion mode in a compact footer.
+Once pi-fusion owns the footer, it also owns rendering status lines that Pi's built-in footer would normally include.
+The current implementation clears pi-fusion's own status key with `ctx.ui.setStatus("fusion", undefined)` but does not consume `footerData.getExtensionStatuses()`, so unrelated extension statuses disappear from the UI.
+
+### Requirements
+
+- R1. When pi-fusion renders a custom footer, it appends a status line for non-empty extension statuses from Pi's footer data provider.
+- R2. The status line is deterministic by extension key so footer output is stable across renders.
+- R3. Status text is sanitized before rendering: ANSI escape sequences are stripped, CR/LF/TAB become spaces, remaining C0/C1 control characters are removed, and repeated whitespace is collapsed.
+- R4. The appended status line is truncated to the available footer width using the same visible-width-aware utility already used elsewhere in the footer.
+- R5. pi-fusion's existing full, compact, and off footer modes keep their current behavior except that full and compact custom footers can preserve other extension statuses.
+- R6. When pi-fusion has no footer text to render, it still restores Pi's built-in footer instead of installing a custom footer.
+
+### Acceptance Examples
+
+- AE1. Given two other extensions register status text, when pi-fusion's custom footer renders, then the returned lines include pi-fusion's two existing footer lines followed by one combined status line.
+- AE2. Given a status value contains a newline or control character, when the status line is rendered, then the returned line contains a single sanitized footer-safe string.
+- AE3. Given no other extension statuses exist, when pi-fusion's custom footer renders, then the returned lines remain the current two-line footer output.
+- AE4. Given footer display is `off` or no panel is selected, when `updateStatus` runs, then pi-fusion restores Pi's built-in footer and does not install a custom footer.
+
+### Scope Boundaries
+
+- Code changes are limited to pi-fusion's custom footer rendering path.
+- It does not redesign footer configuration, add new user-facing settings, or change `/fusion-status` output.
+- It does not vendor or duplicate Pi's built-in footer implementation beyond the extension status preservation required by issue #10.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Render extension statuses as an extra line after pi-fusion's existing footer lines.
+  This preserves the current top/bottom layout and avoids squeezing third-party statuses into either aligned line.
+- KTD2. Sort by extension key and render values only.
+  The key gives deterministic ordering while the value is the user-facing status text Pi extensions registered.
+- KTD3. Keep sanitization local to footer status rendering.
+  The behavior is footer-specific, so a small helper in `src/index.ts` is simpler than a shared utility with no second consumer.
+- KTD4. Unit-test the pure formatting helper and keep integration risk low.
+  The custom footer callback depends on live Pi TUI objects, so the deterministic behavior should be covered through exported pure helpers and the existing harness.
+
+### Assumptions
+
+- The installed Pi API is authoritative: `ReadonlyFooterDataProvider.getExtensionStatuses()` returns a `ReadonlyMap<string, string>`.
+- `ctx.ui.setStatus("fusion", undefined)` continues to prevent pi-fusion from duplicating its own status in the appended line.
+- Other extension status text should appear exactly as registered after sanitization and width truncation; pi-fusion should not add labels or icons.
+
+### Sources & Research
+
+- GitHub issue #10 describes the observed hidden-status behavior and suggested `getExtensionStatuses()` based fix.
+- `src/index.ts` owns `updateStatus`, `fusionFooterText`, `alignLine`, and the custom `ctx.ui.setFooter()` render callback.
+- `node_modules/@earendil-works/pi-coding-agent/dist/core/footer-data-provider.d.ts` confirms `getExtensionStatuses()` is available on the read-only footer data provider.
+- `node_modules/@earendil-works/pi-coding-agent/docs/tui.md` documents `footerData.getExtensionStatuses()` for custom footers.
+- Pi's built-in footer implementation in `node_modules/@earendil-works/pi-coding-agent/dist/modes/interactive/components/footer.js` sorts by key, sanitizes status text, joins values with spaces, and truncates to width.
+- `src/__tests__/index.test.ts` already covers footer display helpers through the repo's custom harness.
+
+---
+
+## Implementation Units
+
+### U1. Add status-line formatting helpers
+
+- **Goal:** Provide deterministic, sanitized, width-aware formatting for extension statuses.
+- **Requirements:** R1, R2, R3, R4, AE1, AE2, AE3
+- **Dependencies:** None
+- **Files:** `src/index.ts`, `src/__tests__/index.test.ts`
+- **Approach:** Add a small exported helper that accepts the read-only status map and width, returns `undefined` for empty maps or all-empty sanitized values, sorts entries by key, strips ANSI escape sequences, replaces CR/LF/TAB with spaces, removes remaining C0/C1 controls, collapses whitespace, joins the remaining values with spaces, and truncates the result to the footer width.
+- **Patterns to follow:** Keep helper style close to `fusionFooterText`, `normalizeFooterDisplay`, and `alignLine`; keep tests in `src/__tests__/index.test.ts` using `test` and `eq`.
+- **Test scenarios:** Empty status map returns `undefined`; two statuses keyed out of insertion order render in key order; newline/tab text plus ESC and BEL controls collapse to a single safe line; narrow width truncates through `truncateToWidth`.
+- **Verification:** The helper behavior is fully covered by unit tests and uses visible-width-aware truncation.
+
+### U2. Append extension statuses from the custom footer render path
+
+- **Goal:** Preserve other extensions' statuses when pi-fusion installs its custom footer.
+- **Requirements:** R1, R4, R5, R6, AE1, AE3, AE4
+- **Dependencies:** U1
+- **Files:** `src/index.ts`, `src/__tests__/index.test.ts`
+- **Approach:** In the existing `ctx.ui.setFooter()` render callback, build the current two lines exactly as today, then append the formatted extension status line when the helper returns one. Add a callback-level test that captures the installed footer factory, invokes `render(width)` with fake footer data, and proves the rendered lines include the appended third-party status line.
+- **Patterns to follow:** Keep all footer rendering inside `updateStatus`; preserve the existing `setFooter(undefined)` branch when `fusionText` is absent.
+- **Test scenarios:** Existing `fusionFooterText` display-mode tests continue to pass; a focused formatting test proves the appended-line input contract used by the render callback; a callback-level test proves `footerData.getExtensionStatuses()` is read and appended; footer display `off` returns no fusion footer text; an empty selected panel returns no fusion footer text.
+- **Verification:** Footer helper tests pass, the callback-level test fails on the current two-line implementation and passes after wiring, and the render callback continues returning two lines when there are no external statuses.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Proves |
+|---|---|---|
+| Unit tests | `npm test` | Existing behavior plus new footer status formatting scenarios pass under the custom harness. |
+| Type check | `npm run check` | Public helper exports and Pi API usage type-check against installed declarations. |
+| Strict dead-code pass | `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` | No unused helpers/imports were introduced. |
+| Package surface | `npm pack --dry-run` | The package still contains the expected publishable files after the change. |
+
+---
+
+## Definition of Done
+
+- U1 and U2 are implemented without adding runtime dependencies.
+- The custom footer appends a sanitized, deterministic third-party extension status line only when statuses exist.
+- Existing footer mode behavior remains intact: `off` restores Pi's built-in footer, and full/compact still render pi-fusion's own text.
+- All verification gates in the Verification Contract pass.
+- Any dead-end implementation attempts are removed from the final diff.
+- The PR references issue #10 and describes the footer status preservation behavior.

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,5 +1,10 @@
-import { test, eq } from "./_harness.ts";
-import { buildInitialState, fusionFooterText, normalizeFooterDisplay } from "../index.ts";
+import { test, eq, fakeModel } from "./_harness.ts";
+import registerFusionExtension, {
+	buildInitialState,
+	formatExtensionStatusLine,
+	fusionFooterText,
+	normalizeFooterDisplay,
+} from "../index.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 
 test("normalizeFooterDisplay accepts known footer modes", () => {
@@ -32,6 +37,30 @@ test("fusionFooterText supports full, compact, and off display modes", () => {
 	);
 });
 
+test("fusionFooterText hides footer text when panel is empty", () => {
+	eq(fusionFooterText(new Set(), undefined, "available", "full"), undefined, "available mode with no panel hides text");
+	eq(fusionFooterText(new Set(), undefined, "off", "full"), "Fusion off", "off mode still reports disabled state");
+});
+
+test("formatExtensionStatusLine sorts, sanitizes, and truncates statuses", () => {
+	const statuses = new Map([
+		["z-token-speed", "\x1B[31m⚡\x1B[0m TPS\n42\tfast\x07"],
+		["a-honcho", " Honcho  ready  "],
+	]);
+	eq(
+		formatExtensionStatusLine(statuses, 80),
+		"Honcho ready ⚡ TPS 42 fast",
+		"status text is sorted by key and sanitized",
+	);
+	eq(formatExtensionStatusLine(statuses, 12), "Honcho re...", "status text truncates to footer width");
+	eq(formatExtensionStatusLine(new Map([["empty", "\n\t\x07"]]), 80), undefined, "empty sanitized statuses are omitted");
+	eq(
+		formatExtensionStatusLine(new Map([["link", "\x1B]8;;https://example.com\x07Token\x1B]8;;\x07 ready"]]), 80),
+		"Token ready",
+		"OSC hyperlinks keep visible text without leaking control payload",
+	);
+});
+
 function fakeContext(branch: unknown[] = []): ExtensionContext {
 	return {
 		sessionManager: {
@@ -39,6 +68,75 @@ function fakeContext(branch: unknown[] = []): ExtensionContext {
 		},
 	} as ExtensionContext;
 }
+
+test("registered footer refresh appends extension statuses", async () => {
+	type FooterFactory = (tui: unknown, theme: { fg: (_color: string, value: string) => string }, footerData: unknown) => { render(width: number): string[] };
+	type EventHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>;
+
+	let footerFactory: FooterFactory | undefined;
+	const handlers = new Map<string, EventHandler>();
+	const branch = [{
+		type: "custom",
+		customType: "fusion-state",
+		data: {
+			selectedIds: ["anthropic/claude-sonnet-4-5"],
+			judgeId: "anthropic/claude-opus-4-5",
+			footerDisplay: "full",
+		},
+	}];
+	const ctx = {
+		cwd: "/tmp/pi-fusion",
+		isProjectTrusted: () => false,
+		getContextUsage: () => ({ percent: 0, contextWindow: 128000 }),
+		model: fakeModel("anthropic", "anthropic/claude-sonnet-4-5"),
+		modelRegistry: {
+			isUsingOAuth: () => false,
+		},
+		sessionManager: {
+			getBranch: () => branch,
+			getEntries: () => [],
+			getSessionName: () => undefined,
+		},
+		ui: {
+			setStatus: () => {},
+			setWidget: () => {},
+			setFooter: (factory: typeof footerFactory) => {
+				footerFactory = factory;
+			},
+		},
+	} as unknown as ExtensionContext;
+	const pi = {
+		registerTool: () => {},
+		registerCommand: () => {},
+		on: (event: string, handler: EventHandler) => {
+			handlers.set(event, handler);
+		},
+		getThinkingLevel: () => "off",
+	};
+
+	registerFusionExtension(pi as never);
+	const refreshFooter = handlers.get("session_start");
+	if (!refreshFooter) throw new Error("expected session_start handler to be registered");
+	await refreshFooter({}, ctx);
+	if (!footerFactory) throw new Error("expected custom footer to be installed");
+
+	const component = footerFactory(
+		{ requestRender: () => {} },
+		{ fg: (_color: string, value: string) => value },
+		{
+			onBranchChange: () => () => {},
+			getGitBranch: () => "feature",
+			getAvailableProviderCount: () => 1,
+			getExtensionStatuses: () => new Map([
+				["z-token-speed", "⚡ TPS 42"],
+				["a-honcho", "Honcho ready"],
+			]),
+		},
+	);
+	const lines = component.render(120);
+	eq(lines.length, 3, "custom footer includes extension status line");
+	eq(lines[2], "Honcho ready ⚡ TPS 42", "extension status line is appended in sorted order");
+});
 
 test("buildInitialState seeds panel tools from config when session has no tool choice", () => {
 	const state = buildInitialState(

--- a/src/index.ts
+++ b/src/index.ts
@@ -111,6 +111,34 @@ function footerStatusLine(display: FooterDisplay): string {
 	return `Footer: ${display}`;
 }
 
+function sanitizeFooterStatusText(text: string): string {
+	return text
+		.replace(/\x1B[\]PX^_][^\x07\x1B]*(?:\x07|\x1B\\)/g, "")
+		.replace(/[\x90\x98\x9D\x9E\x9F][^\x07\x9C]*(?:\x07|\x9C)/g, "")
+		.replace(/\x9B[0-?]*[ -/]*[@-~]/g, "")
+		.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "")
+		.replace(/[\r\n\t]/g, " ")
+		.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "")
+		.replace(/ +/g, " ")
+		.trim();
+}
+
+export function formatExtensionStatusLine(
+	extensionStatuses: ReadonlyMap<string, string>,
+	width: number,
+	ellipsis = "...",
+): string | undefined {
+	if (extensionStatuses.size === 0) return undefined;
+	const statusLine = Array.from(extensionStatuses.entries())
+		.sort(([a], [b]) => a.localeCompare(b))
+		.map(([, text]) => sanitizeFooterStatusText(text))
+		.filter((text) => text.length > 0)
+		.join(" ");
+	if (!statusLine) return undefined;
+	const truncated = truncateToWidth(statusLine, width, ellipsis);
+	return ellipsis.includes("\x1B") ? truncated : truncated.replace(/\x1B\[0m/g, "");
+}
+
 export function fusionFooterText(
 	selectedIds: Set<string>,
 	judgeId: string | undefined,
@@ -218,7 +246,14 @@ function updateStatus(
 
 				const top = alignLine(theme.fg("dim", cwd), fusionText ? theme.fg("dim", fusionText) : "", width);
 				const bottom = alignLine(theme.fg("dim", stats.join(" ")), theme.fg("dim", model), width);
-				return [top, bottom];
+				const lines = [top, bottom];
+				const extensionStatusLine = formatExtensionStatusLine(
+					footerData.getExtensionStatuses(),
+					width,
+					theme.fg("dim", "..."),
+				);
+				if (extensionStatusLine) lines.push(extensionStatusLine);
+				return lines;
 			},
 		};
 	});


### PR DESCRIPTION
## Summary

pi-fusion's custom footer now preserves third-party extension status text instead of replacing Pi's built-in status rendering. Status values from `footerData.getExtensionStatuses()` are sorted by extension key, sanitized for footer safety, and appended as a width-truncated extra footer line when fusion owns the footer.

When fusion has no footer text to render, it still restores Pi's built-in footer. This also records the Compound Engineering local config template used for this LFG run and keeps project-local `*.local.yaml` config ignored.

Fixes #10.

## Validation

- `node --import jiti/register "src/__tests__/index.test.ts"`
- `npm test`
- `npm run check`
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- `npm pack --dry-run`
- Browser pipeline: skipped because this package has no browser routes or dev-server surface.

---

