### PR TITLE
feat: add named panels and reasoning controls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+- Added reusable named panels in `fusion.json`, including a configurable default, independent panel/judge reasoning effort, one-shot `--panel` command selection, and profile-derived snapshots in `/fusion-setup`.
+- Reasoning effort now uses Pi's provider-neutral levels for panel and judge calls. Unsupported levels are omitted per model with a visible warning, including during multi-turn panel tool use.
+- Fusion now publishes its mode, effective named panel, reasoning, judge, and tool state through Pi's keyed status API. It no longer owns or replaces the footer, so built-in and third-party footer extensions compose normally.
+- Require Pi peer packages 0.74.0 or newer, the earliest verified release line containing the reasoning, keyed-status, session, and lifecycle APIs used by Fusion.
+
 ## 0.7.6
 
 - pi-fusion's custom footer now preserves status text from other Pi extensions instead of hiding it while fusion is active. Third-party footer statuses are sorted, sanitized, and width-truncated before rendering.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pi install /path/to/pi-fusion                       # from a local checkout
 
 After installing or updating in a running session, run `/reload`.
 
-There's no build step; pi loads the TypeScript directly via [jiti](https://github.com/unjs/jiti). Requires Node ≥ 22.19.0.
+There's no build step; pi loads the TypeScript directly via [jiti](https://github.com/unjs/jiti). Requires Node ≥ 22.19.0 and Pi ≥ 0.74.0.
 
 ## Quick start
 
@@ -93,9 +93,10 @@ Run a single prompt through fusion without changing the session mode:
 
 ```
 /fusion <prompt>
+/fusion --panel quality <prompt>
 ```
 
-The active model calls fusion, then writes the final answer itself in its normal voice.
+The active model calls fusion, then writes the final answer itself in its normal voice. `--panel <name>` selects a configured named panel for that agent run only; the next run returns to the session/default selection. This stateful `/fusion --panel` form requires interactive mode. In print mode, use `/fusion-report --panel <name> <prompt>` to run the named panel directly.
 
 ### Adding conversation context
 
@@ -120,16 +121,30 @@ Configuration is optional. To pin a panel and judge, create either:
 - `~/.pi/agent/fusion.json` (global)
 - `<cwd>/.pi/fusion.json` (project-local, overrides global; loaded only for trusted projects)
 
-Generate a project-local template with `/fusion-init`, or write one by hand:
+Generate a project-local template with `/fusion-init`, or write one by hand. Named panels let you keep reusable cost/quality trade-offs without editing the file between runs:
 
 ```json
 {
-  "panel": [
-    "openai/gpt-5.5",
-    "z-ai/glm-5.2",
-    "moonshotai/kimi-2.7"
-  ],
-  "judge": "anthropic/claude-opus-4-8",
+  "defaultPanel": "quality",
+  "panelReasoning": "medium",
+  "judgeReasoning": "high",
+  "panels": {
+    "quality": {
+      "models": [
+        "openai/gpt-5.5",
+        "z-ai/glm-5.2",
+        "moonshotai/kimi-2.7"
+      ],
+      "judge": "anthropic/claude-opus-4-8",
+      "panelReasoning": "high",
+      "judgeReasoning": "xhigh"
+    },
+    "fast": {
+      "models": ["openai/gpt-5.5-mini", "google/gemini-2.5-flash"],
+      "judge": "openai/gpt-5.5-mini",
+      "panelReasoning": "low"
+    }
+  },
   "maxPanelModels": 3,
   "maxPanelOutputTokens": 2048,
   "maxCompletionTokens": 4096,
@@ -142,8 +157,12 @@ Generate a project-local template with `/fusion-init`, or write one by hand:
 
 | Field | Default | Description |
 |-------|---------|-------------|
-| `panel` | auto-diverse | Model identifiers in `provider/id` form. Only authed models are used. |
-| `judge` | current model, then first panel model | Model identifier in `provider/id` form. |
+| `panels` | none | Reusable named panels. Each entry requires `models` and may set `judge`, `panelReasoning`, and `judgeReasoning`. |
+| `defaultPanel` | none | Named panel used when there is no one-shot or session selection. An invalid default warns and falls through to legacy or auto selection. |
+| `panel` | auto-diverse | Legacy top-level model identifiers in `provider/id` form. Still supported; only authed models are used. |
+| `judge` | current model, then first panel model | Legacy/default judge model identifier in `provider/id` form. Named panels inherit it when they omit `judge`. |
+| `panelReasoning` | provider default | Reasoning effort for panel calls: `minimal`, `low`, `medium`, `high`, or `xhigh`. Named panels may override it. |
+| `judgeReasoning` | provider default | Independent reasoning effort for judge synthesis, using the same levels. Named panels may override it. |
 | `maxPanelModels` | 3 | Max panel size (1–8). |
 | `maxPanelOutputTokens` | 2048 | Max tokens per panel response. |
 | `maxCompletionTokens` | 4096 | Max tokens for the judge analysis. |
@@ -151,11 +170,13 @@ Generate a project-local template with `/fusion-init`, or write one by hand:
 | `panelTools` | `"none"` | Panel tool access: `"none"`, `"readonly"` (read/grep/find/ls), `"all"` (adds bash/edit/write), or an explicit tool-name list (e.g. `["read", "grep"]`). The list form is **config-file only**. |
 | `maxToolCalls` | 16 | Max tool-call steps **per panel model** when tools are on (1–100). Models batch several calls per turn, so this is the per-agent budget; total ≈ panel size × this. |
 | `panelToolsConsent` | `false` | Pre-authorize mutating tools in non-interactive (`-p`) runs. |
-| `footerDisplay` | `"full"` | Footer verbosity: `"full"` keeps the current mode/panel/judge/tools text, `"compact"` shows only mode + panel count, and `"off"` hides pi-fusion's footer text. |
+| `footerDisplay` | `"full"` | Fusion status verbosity: `"full"` includes mode, active named panel, panel count, reasoning, judge, and tools; `"compact"` shows mode + panel count; `"off"` clears only Fusion's keyed status. The legacy key name is retained for compatibility. |
 
-**Precedence.** Everything resolves session selection (`/fusion-setup`) → `fusion.json` → defaults/auto-selection. The invoking model can't override any of it (the tool takes only the prompt + optional context controls).
+**Precedence.** Everything resolves one-shot `--panel` selection → session snapshot (`/fusion-setup`) → `defaultPanel` → legacy top-level `panel`/`judge` → auto-selection. Project-local config replaces global config rather than merging with it. An explicit unknown, malformed, empty, or unusable named panel fails before any provider call; an invalid `defaultPanel` warns and continues through legacy/auto selection. The invoking model can't override any of this (the tool takes only the prompt + optional context controls).
 
 **How models are resolved.** Reference models as `provider/id` (e.g. `openai/gpt-5.5`); a bare `id` matches by exact id across providers. Only authed models are used; a configured model that isn't authed is skipped with a warning. With no panel configured, fusion auto-selects a diverse set spread across providers. The judge defaults to your current model, falling back to the first panel model.
+
+**Reasoning support.** Fusion asks Pi which provider-neutral reasoning levels each model supports. If a requested level is unsupported, that model runs without the requested reasoning and Fusion reports a non-fatal warning; it does not silently substitute another level. Panel reasoning is preserved across every tool-loop turn and forced finalization. Judge reasoning is used only when at least two panel models succeed and synthesis runs. Reasoning can increase latency, token use, and provider cost.
 
 ### Panel tools (multi-turn)
 
@@ -164,7 +185,9 @@ By default panel models answer in a single turn with no tools. Enable tools to l
 - **`readonly`** (`read`, `grep`, `find`, `ls`): safe; no mutation.
 - **`all`**: adds `bash`, `edit`, `write`. **Off by default** and requires consent (the `/fusion-setup` picker prompts; non-interactive runs need `"panelToolsConsent": true`). Because several models run concurrently, mutating runs **serialize the panel** so they can't clobber each other's writes. Without consent, `all` downgrades to read-only.
 
-Set tools and footer display in `/fusion-setup` (Config section) or in `fusion.json` (`panelTools`, `maxToolCalls`, `footerDisplay`). These are user configuration only — the invoking model has no tool parameters to override them.
+Set tools and Fusion status display in `/fusion-setup` (Config section) or in `fusion.json` (`panelTools`, `maxToolCalls`, `footerDisplay`). These are user configuration only — the invoking model has no tool parameters to override them.
+
+Fusion contributes status through Pi's keyed status API; it does not own or replace the footer. The built-in footer or any third-party footer extension can render Fusion alongside other extension statuses.
 
 > **Note:** enabling panel tools means **file contents (and command output for `all`) are sent to every panel model's provider**. Only enable it where that's acceptable.
 
@@ -176,7 +199,7 @@ No. By default the mode is `available`, so the active model only calls fusion wh
 
 **Does it cost more tokens / money?**
 
-Yes, when it runs. Each panel model is a separate completion, plus one judge call. This is why it's opt-in per task by default. Tune cost with `maxPanelModels`, `maxPanelOutputTokens`, and `maxCompletionTokens`.
+Yes, when it runs. Each panel model is a separate completion, plus one judge call. This is why it's opt-in per task by default. Tune cost with `maxPanelModels`, `maxPanelOutputTokens`, `maxCompletionTokens`, and the two reasoning settings. Higher reasoning effort can consume more of a provider's budget and increase latency.
 
 **Is my code or prompt sent to other providers?**
 
@@ -196,22 +219,23 @@ Only authed models are used. With no configured panel, fusion auto-selects a div
 
 **Does it work in non-interactive (`-p`) runs?**
 
-Yes. `/fusion-setup` is interactive-only, so configure the panel/judge via `fusion.json` instead. To allow mutating panel tools without an interactive prompt, set `"panelToolsConsent": true`.
+Yes. `/fusion-setup` and the stateful `/fusion --panel` form are interactive-only, so configure `defaultPanel` (or legacy panel/judge fields) in `fusion.json`. `/fusion-report --panel <name> <prompt>` works in print mode because it runs Fusion directly. To allow mutating panel tools without an interactive prompt, set `"panelToolsConsent": true`.
 
 **How do I see what the panel and judge actually said?**
 
-`/fusion-report <prompt>` runs fusion directly and writes the raw panel/judge diagnostic report into the editor.
+`/fusion-report [--panel <name>] <prompt>` runs fusion directly and writes the raw panel/judge diagnostic report into the editor.
 
 ## Commands
 
 | Command | What it does |
 |---------|--------------|
-| `/fusion-setup` | Choose the panel, judge, panel tools, and footer display in an interactive picker (interactive mode only). |
+| `/fusion-setup` | Load a named panel or customize a panel snapshot, judge, reasoning, tools, and Fusion status display (interactive mode only). |
 | `/fusion on` \| `available` \| `off` | Set the session mode (aliases: `forced`, `auto`, `disable`). |
 | `/fusion` | With no argument, toggle between `available` and `forced`. |
 | `/fusion <prompt>` | Force fusion for a single prompt, then answer normally. |
-| `/fusion-status` | Show the current mode, panel, and judge. |
-| `/fusion-report <prompt>` | Run fusion directly and write the raw panel/judge diagnostic report into the editor. |
+| `/fusion --panel <name> <prompt>` | Use a named panel for this interactive agent run only, then return to the prior selection. |
+| `/fusion-status` | Show the current mode, named panel when applicable, panel snapshot, reasoning, judge, tools, and Fusion status verbosity. |
+| `/fusion-report [--panel <name>] <prompt>` | Run fusion directly and write the raw panel/judge diagnostic report into the editor; named selection also works in print mode. |
 | `/fusion-init` | Write a `.pi/fusion.json` template (confirms before overwriting; trusted projects only). |
 
 ### `/fusion-setup` controls
@@ -219,9 +243,9 @@ Yes. `/fusion-setup` is interactive-only, so configure the panel/judge via `fusi
 Two sections, **Models** and **Config**, with the live panel/judge selection shown at the top. **Tab** switches sections; **Enter** saves, **Esc** cancels.
 
 - **Models:** `↑/↓` move · `p` toggle panel · `j` toggle judge (independent of the panel; can be any model or left unset for auto) · `c` clear panel · `/` search.
-- **Config:** `↑/↓` move · `Space` / `←→` change a value. Settings: **Panel tools** (`none` → `readonly` → `all`), **Max tool calls** (`4`/`8`/`12`/`16`/`25`/`50`/`100`), and **Footer** (`full` → `compact` → `off`).
+- **Config:** `↑/↓` move · `Space` / `←→` change a value. Settings: **Named panel** (when configured), **Panel reasoning**, **Judge reasoning**, **Panel tools** (`none` → `readonly` → `all`), **Max tool calls** (`4`/`8`/`12`/`16`/`25`/`50`/`100`), and **Fusion status** (`full` → `compact` → `off`).
 
-Selections (panel, judge, mode) are saved in the session and restored on `/resume`.
+Selections (panel, judge, reasoning, tools, status display, and mode) are saved as a detached session snapshot and restored on `/resume`. Loading a named panel copies its resolved values; the saved snapshot does not follow later config-file edits.
 
 ## Development
 
@@ -243,5 +267,5 @@ Contributions are welcome. See [CONTRIBUTING.md](CONTRIBUTING.md) for setup and 
 - Uses pi's authed models instead of OpenRouter's catalog.
 - Does not inject `openrouter:web_search` or `openrouter:web_fetch` into panel/judge calls (pi has its own tools; the outer model can still use them).
 - No recursion-depth header is needed; inner calls use `complete()` directly and never see the `fusion` tool.
-- Adds interactive panel/judge selection via `/fusion-setup`.
+- Adds named panels and interactive panel/judge/reasoning selection via `/fusion-setup`.
 - Adds session modes (`available`, `forced`, `off`), diagnostic reports (`/fusion-report`), and session-state persistence.

--- a/docs/pi-api-notes.md
+++ b/docs/pi-api-notes.md
@@ -29,9 +29,6 @@ intentional; each carries a matching `// pi gap:` comment at its call site.
 
 These work fine but are undocumented; relying on them is a small risk:
 - `getSelectListTheme()` (only `getSettingsListTheme` is in `docs/tui.md`).
-- `footerData.getAvailableProviderCount()` and the full `FooterData` shape (`docs/extensions.md`
-  shows only the 2-arg form).
 - `ModelRegistry.isUsingOAuth(model)` and `getAvailable()`.
 - The tool-definition factories (`createReadToolDefinition` etc.) and the `AgentToolResult` shape
   used by panel tool loops.
-- `ctx.model.reasoning`.

--- a/docs/plans/2026-07-10-001-feat-fusion-profiles-reasoning-status-plan.md
+++ b/docs/plans/2026-07-10-001-feat-fusion-profiles-reasoning-status-plan.md
@@ -1,0 +1,302 @@
+---
+title: "Fusion Profiles, Reasoning, and Status Integration - Plan"
+type: "feat"
+date: "2026-07-10"
+deepened: "2026-07-10"
+artifact_contract: "ce-unified-plan/v1"
+artifact_readiness: "implementation-ready"
+execution: "code"
+product_contract_source: "ce-plan-bootstrap"
+---
+
+# Fusion Profiles, Reasoning, and Status Integration - Plan
+
+## Goal Capsule
+
+| Field | Value |
+|---|---|
+| Objective | Resolve GitHub issues #12, #13, and #14 by adding reusable named panels, independent panel/judge reasoning effort, and status-only footer integration. |
+| Authority | Current GitHub issue contracts, installed Pi 0.79.3 declarations/provider behavior, repository instructions, then existing implementation patterns. |
+| Execution profile | Test-protected cross-cutting feature work across config resolution, runtime calls, session/UI state, commands, and documentation. |
+| Stop conditions | Stop if an installed Pi API contradicts the documented reasoning/status contract or if implementation would expose model/profile/reasoning control to the invoking model. |
+| Tail ownership | LFG owns implementation, simplification, review fixes, verification, commit, PR, and CI watch. |
+
+---
+
+## Product Contract
+
+### Summary
+
+Add user-owned named panel profiles and independent reasoning effort while keeping legacy configuration valid.
+Allow commands to select a named profile for one run and setup to save a profile-derived session snapshot.
+Publish Fusion state through Pi's keyed status API so any active footer owner renders it without duplication or clobbering.
+
+### Problem Frame
+
+One top-level panel cannot represent fast, quality, budget, and review tradeoffs without repeated config edits.
+Panel and judge calls also lack access to Pi's provider-neutral reasoning levels, preventing users from choosing a stronger effort for difficult deliberations.
+The current custom footer now duplicates other footer extensions and can clear their singleton footer ownership, even though Fusion only needs to contribute status text.
+
+### Requirements
+
+**Named profiles**
+
+- R1. Users can define named profiles containing model identifiers, an optional judge, and optional panel/judge reasoning overrides.
+- R2. `defaultPanel` selects the default named profile when no one-shot or session snapshot is active.
+- R3. Existing top-level `panel` and `judge` configuration behaves unchanged when named profiles are absent or no valid default is selected.
+- R4. `/fusion --panel <name> <prompt>` in interactive mode and `/fusion-report --panel <name> <prompt>` in interactive or print mode use the named panel for that invocation only; print-mode `/fusion --panel` rejects with guidance because it cannot carry extension state into a later tool call.
+- R5. `/fusion-setup` can load a named profile and persist its resolved models, judge, and reasoning as a custom session snapshot.
+- R6. An explicitly requested unknown, malformed, empty, or zero-auth profile fails clearly without falling back to another panel.
+- R7. An invalid configured `defaultPanel` warns and falls through to legacy configuration or auto-diverse selection.
+
+**Reasoning effort**
+
+- R8. Top-level `panelReasoning` and `judgeReasoning` accept Pi's `minimal`, `low`, `medium`, `high`, and `xhigh` levels.
+- R9. Named profiles may override the top-level panel and judge reasoning independently.
+- R10. Panel effort applies to every panel completion, including tool-loop turns and forced finalization; judge effort applies only when judge synthesis runs.
+- R11. A requested effort unsupported by a model is omitted for that model with a visible non-fatal warning rather than silently clamped.
+
+**User control and observability**
+
+- R12. The registered `fusion` tool continues to expose only prompt and context controls; models cannot choose profiles, panel members, judge, reasoning, token budgets, temperature, tools, or consent.
+- R13. Progress, diagnostics, `/fusion-status`, setup summaries, and full status text identify the effective profile when one is active and report effective reasoning configuration.
+- R14. Project-local config continues to take precedence over global config without merging files.
+
+**Status coexistence**
+
+- R15. Fusion publishes full or compact text only through `ctx.ui.setStatus("fusion", text)`.
+- R16. `footerDisplay: "off"` clears only Fusion's keyed status with `setStatus("fusion", undefined)`.
+- R17. No Fusion path calls `setFooter`, including cleanup, off, lifecycle refresh, or missing-panel paths.
+- R18. The backward-compatible `footerDisplay` key remains supported but is described as Fusion status verbosity.
+
+**Runtime compatibility**
+
+- R19. Published package metadata requires `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` 0.74.0 or newer, the earliest published package line verified to contain the required reasoning, status, session-id, and agent-lifecycle contracts.
+
+### Acceptance Examples
+
+- AE1. Given named profiles `quality` and `fast` with `defaultPanel: "quality"`, a normal tool call uses `quality`, while `/fusion-report --panel fast ...` uses `fast` once and the next normal call returns to `quality`.
+- AE2. Given a legacy config with only top-level `panel` and `judge`, resolution and displayed state match current behavior.
+- AE3. Given `/fusion --panel missing explain this`, the command reports the missing named panel before sending the forced prompt and incurs no provider calls.
+- AE4. Given `panelReasoning: "high"` and a named profile with `judgeReasoning: "xhigh"`, supported panel models receive `high`, the judge receives `xhigh`, and unsupported models run without the requested effort plus a warning.
+- AE5. Given a tool-enabled panel model reaches its loop cap, its final tool-free completion retains the selected panel reasoning level.
+- AE6. Given another extension owns the footer, Fusion full/compact/off updates only the `fusion` status key and never replaces or restores the singleton footer.
+- AE7. Given a named profile is loaded in setup and then manually edited, the saved session is a custom snapshot rather than a live link to later config-file changes.
+
+### Scope Boundaries
+
+- Per-model reasoning objects, profile inheritance, autonomous model-selected profiles, and generalized presets for every numeric/tool option are deferred.
+- Named profiles contain models, judge, and role-level reasoning only; existing global token, temperature, tool, consent, and display knobs remain shared.
+- This work does not publish a release or tag; it records user-visible changes for the next release.
+- Fusion does not become a footer owner and does not reproduce Pi's cwd, usage, model, or third-party status rendering.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Normalize a selected named profile into the existing panel/judge resolution inputs instead of creating a second model-resolution algorithm.
+  This preserves auth filtering, size limits, deduplication, warnings, and fallback behavior in one place.
+- KTD2. Treat command `--panel` as consume-once extension state, while setup persists a profile-derived session snapshot.
+  This matches invocation syntax without granting the later model-controlled tool call a profile parameter or surprising subsequent calls.
+- KTD3. Make explicit profile selection strict and configured defaults permissive.
+  Explicit requests must not silently change cost or quality; a stale default should keep the extension usable with a warning and legacy/auto fallback.
+- KTD4. Use Pi's exported reasoning vocabulary and `getSupportedThinkingLevels(model)` before passing the generic `reasoning` option through the existing `complete()` path.
+  The installed providers already map that option, so provider-specific payload construction and a completion-path migration are unnecessary.
+- KTD5. Omit unsupported reasoning rather than calling Pi's clamp helper.
+  Silent substitution would violate the requested effort, while a warning preserves transparency and graceful mixed-panel execution.
+- KTD6. Replace the custom footer renderer with one final keyed status update.
+  `setStatus` composes with built-in and third-party footer owners; `setFooter` is singleton ownership and is outside Fusion's responsibility.
+- KTD7. Centralize named-profile argument parsing and effective-config selection in pure helpers.
+  `/fusion`, `/fusion-report`, resolution, setup, status, and lifecycle refresh must not drift on precedence or error semantics.
+- KTD8. Require Pi 0.74.0 or newer in peer metadata instead of maintaining a partial compatibility shim.
+  Set `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` to `>=0.74.0`; npm tarballs confirm this earliest published line already contains the generic reasoning levels/provider mappings, keyed status, session ID, and agent lifecycle APIs used by the design.
+
+### Assumptions
+
+- One-shot `/fusion --panel` state is extension-controlled and bound to the current session plus the agent turn started by the command.
+- The pending profile survives unrelated tools and internal turns in that agent run, is consumed atomically by the first Fusion execution even when strict resolution fails, and clears on agent end, session replacement/tree navigation, reload, or a newer one-shot command.
+- Setup profile selection copies models, judge, and reasoning into a detached custom session snapshot.
+- Reasoning warnings are computed deterministically before concurrent panel calls, and judge warnings are added only when judge synthesis is attempted.
+- Named profiles use `models` rather than the legacy top-level `panel` key to match issue #12's proposed profile shape.
+- User-facing text calls the feature “named panels”; implementation prose may use “profile” for the config object when needed to distinguish it from the resolved model list.
+- `footerDisplay` retains its public name to avoid an unnecessary config migration.
+
+### High-Level Technical Design
+
+```mermaid
+flowchart TB
+  A["User command, setup snapshot, or tool call"] --> B{"One-shot profile requested?"}
+  B -->|yes| C["Resolve named profile strictly"]
+  B -->|no| D{"Session snapshot present?"}
+  D -->|yes| E["Use session models, judge, and reasoning"]
+  D -->|no| F{"Valid defaultPanel?"}
+  F -->|yes| G["Normalize named profile"]
+  F -->|no| H{"Legacy panel or judge?"}
+  H -->|yes| I["Use legacy config"]
+  H -->|no| J["Auto-diverse resolution"]
+  C --> P{"Named panel valid and has an authed model?"}
+  P -->|no| Q["Structured strict error; no provider call"]
+  P -->|yes| K["Existing auth-aware model resolver"]
+  E --> K
+  G --> K
+  I --> K
+  J --> K
+  K --> L["Panel calls with supported panel reasoning"]
+  L --> M{"At least two successful responses?"}
+  M -->|yes| N["Judge call with supported judge reasoning"]
+  M -->|no| O["Return partial or failure result"]
+```
+
+```mermaid
+stateDiagram-v2
+  [*] --> Idle
+  Idle --> Pending: /fusion --panel name prompt
+  Pending --> Consumed: next fusion tool execution
+  Pending --> Cleared: agent or session boundary without execution
+  Consumed --> Idle: one-shot override removed
+  Cleared --> Idle
+  Idle --> SessionSnapshot: /fusion-setup saves profile or custom selection
+  SessionSnapshot --> SessionSnapshot: normal fusion calls
+  SessionSnapshot --> Idle: session state replaced or session ends
+```
+
+### System-Wide Impact
+
+| Surface | Effective-state responsibility | Failure and parity requirement |
+|---|---|---|
+| Registered `fusion` tool | Consume user/session/config state without accepting config parameters. | Strict selection errors return structured Fusion failure before provider calls; effective profile and reasoning remain visible in details. |
+| `/fusion` | Parse and acknowledge a one-shot named panel, arm it for the command-created agent run, then send the forced prompt. | A missing/unusable panel is rejected before the prompt is sent; print mode rejects the stateful form; an unused selection warns and clears at agent/session end. |
+| `/fusion-report` | Parse the same syntax and pass a direct one-shot override to execution. | Errors, warnings, and effective choices match the tool path without modifying the editor with a misleading report. |
+| `/fusion-setup` | Copy a configured profile into a persistent session snapshot. | The saved values are detached from later config-file changes and resume as a custom snapshot. |
+| `/fusion-status` and lifecycle refresh | Render the same normalized session/config state used by execution. | Every refresh publishes `text | undefined`, so switching to an empty session clears stale Fusion status. |
+| Progress and `FusionDetails` | Report the requested/effective profile plus role-level reasoning and affected-model warnings. | Cost/control observability does not depend on full or compact status display. |
+| Package consumers | Resolve Pi APIs from peers at or above the verified 0.74.0 minimum. | Installation rejects older unsupported peer versions rather than failing after load. |
+
+### Risks and Dependencies
+
+- **One-shot state can leak to unrelated work.** Bind it to `sessionManager.getSessionId()` and the command-created agent run, consume it once, and clear it at agent/session terminal paths while allowing unrelated tools and internal turns before Fusion.
+- **Default fallback can skip the legacy panel.** Model resolution must iterate ordered candidates—session snapshot, named default, legacy config, then auto—while reusing one identifier/auth helper; tests distinguish malformed, zero-auth, partial-auth, and valid candidates.
+- **Strict failures can spend against fallback models or crash command flows.** Use a typed selection outcome and convert strict errors into the existing structured Fusion failure before any completion; slash commands surface the same error text.
+- **Display and execution can diverge.** All command, setup, status, preview, and execution surfaces consume the same normalized effective-state result, with a parity matrix covered by tests.
+- **Reasoning changes token use, latency, and cost by provider.** Preserve current token-cap inputs, document that thinking may consume provider budget, and cover reasoning-enabled caps, tool-loop finalization, judge budgets, and unset-reasoning characterization.
+- **Wildcard peers can hide API incompatibility.** Set the aligned Pi peer minimum to 0.74.0, the earliest published tarballs verified to contain every required contract, and update lock/package verification.
+- **Keyed status can become stale.** Lifecycle refresh always calls `setStatus("fusion", computedText)` even when the state is empty; no cleanup path touches a foreign footer or status key.
+
+### Sources and Research
+
+- GitHub issues [#12](https://github.com/synthetic-recon/pi-fusion/issues/12), [#13](https://github.com/synthetic-recon/pi-fusion/issues/13), and [#14](https://github.com/synthetic-recon/pi-fusion/issues/14) define the user-facing contracts.
+- `src/config.ts`, `src/models.ts`, and `src/fusion.ts` establish config defaults and session/config/auto model precedence.
+- `src/index.ts` and `src/ui.ts` establish custom-entry session persistence, command flow, status display, and the two-section setup UI.
+- `node_modules/@earendil-works/pi-ai/dist/types.d.ts`, `models.d.ts`, and built-in provider implementations establish the generic reasoning levels, support query, and provider mappings used by `complete()`.
+- `node_modules/@earendil-works/pi-coding-agent/dist/core/extensions/types.d.ts` distinguishes keyed `setStatus` composition from singleton `setFooter` ownership.
+- The earlier footer-preservation plan in `docs/plans/2026-06-30-001-fix-footer-extension-statuses-plan.md` explains the custom-footer approach that issue #14 now supersedes.
+- No `CONCEPTS.md` or `docs/solutions/` corpus exists, so there are no institutional learnings to carry forward.
+
+---
+
+## Implementation Units
+
+### U1. Define and normalize named profile configuration
+
+- **Goal:** Add a runtime-safe, backward-compatible effective-config resolver for named profiles and role-level reasoning.
+- **Requirements:** R1, R2, R3, R6, R7, R8, R9, R14; AE1, AE2, AE3
+- **Dependencies:** None
+- **Files:** `src/types.ts`, `src/config.ts`, `src/__tests__/config.test.ts`
+- **Approach:** Define named profile and reasoning fields, validate parsed JSON shapes at the selection boundary, and return effective panel/judge/reasoning plus selected-profile metadata and deterministic warnings/errors. Keep `loadConfig()` first-file-wins behavior and preserve existing numeric defaults.
+- **Execution note:** Start with failing pure tests for precedence, strict explicit selection, permissive invalid defaults, malformed data, and legacy compatibility.
+- **Patterns to follow:** `applyDefaults()` as the normalization boundary; current plain interfaces and warning strings; no runtime dependency additions.
+- **Test scenarios:** Explicit named selection returns its models/judge/reasoning; `defaultPanel` resolves when no override exists; profile reasoning overrides top-level reasoning by role; legacy-only config is unchanged; unknown/malformed/empty explicit profiles return a strict error; invalid default warns and falls through; max-panel configuration remains available to model resolution.
+- **Verification:** All effective-config outputs are deterministic and no caller must reimplement named-profile precedence.
+
+### U2. Integrate profiles with model resolution and observable results
+
+- **Goal:** Make resolution and execution use the same effective profile while preserving the existing auth-aware resolver.
+- **Requirements:** R2, R3, R6, R7, R12, R13, R14; AE1, AE2, AE3
+- **Dependencies:** U1
+- **Files:** `src/fusion.ts`, `src/models.ts`, `src/types.ts`, `src/__tests__/models.test.ts`, `src/__tests__/fusion.test.ts`
+- **Approach:** Normalize config into an ordered candidate result before building existing resolve options, carry profile metadata and config warnings through both preview and execution paths, fail strict explicit profiles before fallback, retry legacy config after an unusable permissive default, and expose the active profile in progress/details without adding registered tool parameters.
+- **Patterns to follow:** `buildResolveOptions()`, `resolvePanelAndJudge()`, `ResolveResult.warnings`, and current `FusionDetails` diagnostics.
+- **Test scenarios:** Named models use existing unknown/unauthed filtering and configured size limits; a zero-auth explicit profile fails with zero provider calls; malformed, zero-auth, partially authed, and valid defaults advance through the correct candidates; legacy recovery occurs before auto-selection; named judge fallback remains deterministic; preview and execution select the same profile; tool schema remains free of config override fields.
+- **Verification:** Resolution behavior has one model-selection implementation, and diagnostics identify the profile and warnings that shaped execution.
+
+### U3. Add one-shot command selection and setup snapshots
+
+- **Goal:** Let users select profiles safely from both command and interactive surfaces.
+- **Requirements:** R4, R5, R6, R12, R13; AE1, AE3, AE7
+- **Dependencies:** U1, U2
+- **Files:** `src/index.ts`, `src/ui.ts`, `src/__tests__/index.test.ts`, `src/__tests__/ui.test.ts`
+- **Approach:** Add a shared leading-option parser that consumes only `--panel <name>` and preserves the remaining prompt verbatim. Bind `/fusion` consume-once state to the current session and command-created agent run, pass a direct override to `/fusion-report`, and consume or clear it atomically at agent/session boundaries. Reject stateful `/fusion --panel` in print mode. Put a keyboard-operated Profile row first in setup Config when named panels exist; selecting a name copies its models/judge/reasoning into a detached session snapshot. Hide the row when no named panels exist and preserve save/cancel behavior.
+- **Execution note:** Characterize current mode-command and prompt parsing before adding flags, then prove the delayed `/fusion` handoff and cleanup paths.
+- **Patterns to follow:** `persistSessionState()`/`restoreSessionState()`, `sessionFusionOptions()`, generic setup `ConfigRow` cycling, and current command print/UI dual behavior.
+- **Test scenarios:** Both commands consume only a leading profile option and preserve the remaining prompt verbatim; missing `--panel` value and unknown names fail before dispatch; print-mode `/fusion --panel` rejects with guidance while print-mode report works; pending selection is session-bound and consumed once; setup copies named profile values into a detached snapshot; resumed snapshots stay frozen after config edits.
+- **Verification:** One-shot and persistent selection semantics are distinct, visible, and cannot leak across unrelated turns or sessions.
+
+### U4. Thread independent reasoning through all model calls
+
+- **Goal:** Apply supported panel and judge reasoning without provider-specific branching or silent substitution.
+- **Requirements:** R8, R9, R10, R11, R12, R13; AE4, AE5
+- **Dependencies:** U1, U2
+- **Files:** `src/llm.ts`, `src/fusion.ts`, `src/types.ts`, `src/__tests__/llm.test.ts`, `src/__tests__/fusion.test.ts`
+- **Approach:** Extend the existing raw completion options with Pi's generic reasoning type, use a pure helper backed by `getSupportedThinkingLevels(model)` to return either the requested level or a warning, and pass the result separately to panel and judge calls. Keep `complete()` because installed built-in providers already translate generic reasoning; reuse the constructed panel options through every tool-loop iteration and forced finalization.
+- **Execution note:** Preserve the existing `complete()` path and characterize no-reasoning plus temperature-suppression behavior before adding effort.
+- **Patterns to follow:** `buildCompleteOptions()`, `getSupportsTemperature()`, immutable tool-loop options, and existing warning aggregation.
+- **Test scenarios:** Supported minimal/high levels pass through; unsupported non-reasoning and unsupported xhigh levels are omitted with model-specific warnings; mixed panels continue; panel and judge levels remain independent; judge warnings appear only when synthesis runs; tool-loop turns and finalization share one reasoning option; reasoning-enabled token caps and judge budgets keep their current input semantics; unset reasoning leaves current options and temperature suppression unchanged.
+- **Verification:** Every completion site receives the intended supported role-level effort, and unsupported requests remain observable without breaking partial-success behavior.
+
+### U5. Relinquish footer ownership and publish keyed status
+
+- **Goal:** Make Fusion coexist with any built-in or third-party footer owner.
+- **Requirements:** R13, R15, R16, R17, R18; AE6
+- **Dependencies:** U3
+- **Files:** `src/index.ts`, `src/ui.ts`, `src/__tests__/index.test.ts`
+- **Approach:** Reduce `updateStatus()` to compute the current full/compact/off Fusion text and issue one `setStatus("fusion", text | undefined)` call. Invoke it unconditionally on relevant lifecycle refreshes so empty sessions clear stale text. Remove custom footer rendering, footer-data formatting helpers, unused widget cleanup, ownership restoration, and related imports/tests. Full status orders mode, named panel or custom marker, panel count, panel/judge reasoning, judge, then tools; compact remains mode plus panel count; off and empty publish `undefined`.
+- **Execution note:** Replace the current custom-footer regression test with a failing non-ownership test before deleting the renderer.
+- **Patterns to follow:** Pi's keyed status contract and the existing pure `fusionFooterText()` formatting boundary.
+- **Test scenarios:** Full formatting preserves the canonical priority order; compact publishes only mode and panel count; off and missing available panel clear only `fusion`; a populated-to-unconfigured lifecycle transition clears stale Fusion text; a fake foreign footer and foreign status remain untouched; `setFooter` is never called.
+- **Verification:** Static search and lifecycle tests prove no runtime path in Fusion calls `setFooter`.
+
+### U6. Update public configuration and contributor-facing documentation
+
+- **Goal:** Document the final behavior and remove descriptions of Fusion as a footer owner.
+- **Requirements:** R1, R2, R4, R5, R8, R9, R11, R13, R18
+- **Dependencies:** U1, U2, U3, U4, U5
+- **Files:** `README.md`, `CHANGELOG.md`, `docs/pi-api-notes.md`, `src/config.ts`, `package.json`, `package-lock.json`
+- **Approach:** Update the generated config example, config reference, precedence, command examples, setup behavior, reasoning support/warnings, status terminology, privacy/cost guidance, verified Pi peer minimum, and next-release changelog. Remove resolved custom-footer API notes while retaining unrelated Pi workarounds.
+- **Patterns to follow:** Current README configuration table, exact JSON examples, and changelog user-outcome language.
+- **Test expectation:** No new unit behavior; `/fusion-init` output is covered by U1 config tests, and package/document verification catches stale publish surfaces.
+- **Verification:** Documentation examples match accepted config types and command semantics, and no text claims Fusion owns or restores the footer.
+
+---
+
+## Verification Contract
+
+| Gate | Command | Proves |
+|---|---|---|
+| Focused config/model tests | `node --import jiti/register src/__tests__/config.test.ts` and `node --import jiti/register src/__tests__/models.test.ts` | Profile precedence, validation, auth filtering, and legacy compatibility. |
+| Focused runtime tests | `node --import jiti/register src/__tests__/fusion.test.ts` and `node --import jiti/register src/__tests__/llm.test.ts` | Role-level reasoning support/warnings and pipeline propagation. |
+| Focused command/UI tests | `node --import jiti/register src/__tests__/index.test.ts` and `node --import jiti/register src/__tests__/ui.test.ts` | One-shot lifecycle, session snapshots, status publication, and footer non-ownership. |
+| Full test suite | `npm test` | New and existing behavior passes under the custom harness. |
+| Type check | `npm run check` | Public config/session/result types and installed Pi APIs compile. |
+| Strict dead-code check | `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` | Removed footer helpers and new profile/reasoning plumbing leave no dead symbols. |
+| Package surface | `npm pack --dry-run` | Published files and documentation remain complete without test leakage. |
+| Live Pi smoke | `pi -e .` | Named profile commands/setup work with real auth state, reasoning warnings are readable, and Fusion status coexists with another footer owner. |
+
+---
+
+## Definition of Done
+
+- U1-U6 satisfy every cited requirement and acceptance example.
+- All three open issues are referenced and closed by the pull request when the implemented behavior matches their contracts.
+- Explicit profile selection never silently substitutes a different panel, and configured defaults degrade with a warning.
+- The invoking model cannot control profile, panel, judge, reasoning, tools, consent, temperature, or budgets.
+- Default profile, explicit one-shot, session snapshot, legacy config, and auto-selection produce consistent effective state across commands, setup, status, tool execution, lifecycle refresh, progress, and diagnostics.
+- One-shot state is session/turn bound, consumed at most once, and cleared on every terminal path without crossing sessions.
+- Supported reasoning reaches all intended completion calls; unsupported reasoning is omitted with deterministic warnings.
+- Fusion publishes only keyed status and contains no `setFooter` call or custom footer renderer.
+- Legacy config remains valid, unaffected pre-existing tests continue to pass, and obsolete custom-footer tests are replaced by keyed-status non-ownership coverage.
+- Package metadata requires Pi 0.74.0 or newer, matching the earliest published package line verified to contain the APIs used by the implementation.
+- README, changelog, Pi API notes, and generated config examples match the shipped behavior.
+- Every verification gate passes, including a live coexistence smoke test where the environment permits it.
+- Dead-end experiments, temporary diagnostics, and abandoned code paths are absent from the final diff.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": "*",
-        "@earendil-works/pi-coding-agent": "*",
-        "@earendil-works/pi-tui": "*",
+        "@earendil-works/pi-ai": ">=0.74.0",
+        "@earendil-works/pi-coding-agent": ">=0.74.0",
+        "@earendil-works/pi-tui": ">=0.74.0",
         "typebox": "*"
       }
     },

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@earendil-works/pi-ai": "*",
-    "@earendil-works/pi-coding-agent": "*",
-    "@earendil-works/pi-tui": "*",
+    "@earendil-works/pi-ai": ">=0.74.0",
+    "@earendil-works/pi-coding-agent": ">=0.74.0",
+    "@earendil-works/pi-tui": ">=0.74.0",
     "typebox": "*"
   },
   "devDependencies": {

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Tests for named-panel config selection and backward-compatible defaults.
+ */
+
+import {
+	applyDefaults,
+	generateConfigExample,
+	parseFusionConfig,
+	resolveEffectiveConfig,
+} from "../config.ts";
+import type { FusionConfig } from "../types.ts";
+import { eq, test } from "./_harness.ts";
+
+const namedConfig: FusionConfig = {
+	panel: ["legacy/panel"],
+	judge: "legacy/judge",
+	panelReasoning: "low",
+	judgeReasoning: "medium",
+	defaultPanel: "quality",
+	panels: {
+		quality: {
+			models: ["openai/gpt-5.5", "anthropic/claude-sonnet-5"],
+			judge: "openai/gpt-5.5",
+			panelReasoning: "high",
+		},
+		fast: {
+			models: ["openai/gpt-5.4"],
+			judgeReasoning: "minimal",
+		},
+	},
+};
+
+test("explicit named panel overrides the default and inherits omitted role settings", () => {
+	const result = resolveEffectiveConfig(namedConfig, {}, "fast");
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.profileName, "fast", "explicit panel is identified");
+	eq(result.source, "explicit", "selection source is explicit");
+	eq(result.config.panel, ["openai/gpt-5.4"], "named models replace legacy panel");
+	eq(result.config.judge, "legacy/judge", "omitted named judge inherits top-level judge");
+	eq(result.config.panelReasoning, "low", "omitted panel reasoning inherits top-level effort");
+	eq(result.config.judgeReasoning, "minimal", "named judge reasoning overrides top-level effort");
+	eq(result.warnings, [], "valid explicit panel has no warnings");
+});
+
+test("defaultPanel selects a named panel and applies role overrides independently", () => {
+	const result = resolveEffectiveConfig(namedConfig);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.profileName, "quality", "default panel is identified");
+	eq(result.source, "default", "selection source is default");
+	eq(result.config.panel, ["openai/gpt-5.5", "anthropic/claude-sonnet-5"], "default models selected");
+	eq(result.config.judge, "openai/gpt-5.5", "default judge selected");
+	eq(result.config.panelReasoning, "high", "named panel reasoning overrides top-level effort");
+	eq(result.config.judgeReasoning, "medium", "omitted named judge effort inherits top-level effort");
+});
+
+test("legacy-only config remains unchanged apart from numeric defaults", () => {
+	const legacy: FusionConfig = {
+		panel: ["anthropic/claude-sonnet-4-5"],
+		judge: "anthropic/claude-opus-4-5",
+		maxPanelModels: 6,
+		panelTools: "readonly",
+	};
+	const result = resolveEffectiveConfig(legacy);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.source, "legacy", "legacy source retained");
+	eq(result.profileName, undefined, "legacy config has no profile name");
+	eq(result.config.panel, legacy.panel, "legacy panel retained");
+	eq(result.config.judge, legacy.judge, "legacy judge retained");
+	eq(result.config.maxPanelModels, 6, "configured panel limit retained");
+	eq(result.config.panelTools, "readonly", "unrelated config retained");
+});
+
+test("explicit unknown named panel returns a strict typed error", () => {
+	const result = resolveEffectiveConfig(namedConfig, {}, "missing");
+	if (result.ok) throw new Error("expected strict selection failure");
+
+	eq(result.error.code, "unknown_named_panel", "unknown panel error code");
+	eq(result.error.panelName, "missing", "unknown panel error identifies request");
+	eq(result.warnings, [], "strict error does not downgrade to a warning");
+});
+
+test("explicit malformed or empty named panels return strict errors", () => {
+	const config = {
+		panels: {
+			empty: { models: [] },
+			malformed: { models: ["valid/model", 42] },
+			badReasoning: { models: ["valid/model"], panelReasoning: "maximum" },
+		},
+	} as unknown as FusionConfig;
+
+	for (const name of ["empty", "malformed", "badReasoning"]) {
+		const result = resolveEffectiveConfig(config, {}, name);
+		if (result.ok) throw new Error(`expected ${name} to fail`);
+		eq(result.error.code, "invalid_named_panel", `${name} error code`);
+		eq(result.error.panelName, name, `${name} error identifies request`);
+	}
+});
+
+test("invalid configured default warns and falls through to legacy config", () => {
+	const config: FusionConfig = {
+		panel: ["legacy/panel"],
+		judge: "legacy/judge",
+		defaultPanel: "missing",
+		panels: {},
+	};
+	const result = resolveEffectiveConfig(config);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.source, "legacy", "invalid default falls through");
+	eq(result.config.panel, ["legacy/panel"], "legacy panel retained after invalid default");
+	eq(result.config.judge, "legacy/judge", "legacy judge retained after invalid default");
+	if (!result.warnings.some((warning) => warning.includes('defaultPanel "missing"'))) {
+		throw new Error(`missing deterministic default warning: ${JSON.stringify(result.warnings)}`);
+	}
+});
+
+test("invalid top-level reasoning is omitted with deterministic warnings", () => {
+	const config = {
+		panel: ["legacy/panel"],
+		panelReasoning: "maximum",
+		judgeReasoning: 3,
+	} as unknown as FusionConfig;
+	const result = resolveEffectiveConfig(config);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.config.panelReasoning, undefined, "invalid panel effort omitted");
+	eq(result.config.judgeReasoning, undefined, "invalid judge effort omitted");
+	eq(result.warnings.length, 2, "both invalid efforts warn");
+});
+
+test("effective selection preserves applyDefaults overrides and numeric config", () => {
+	const result = resolveEffectiveConfig(
+		{ ...namedConfig, maxPanelModels: 7 },
+		{ max_completion_tokens: 8192, max_tool_calls: 25 },
+		"quality",
+	);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.config.maxPanelModels, 7, "configured max panel remains available");
+	eq(result.config.maxCompletionTokens, 8192, "runtime numeric override retained");
+	eq(result.config.maxToolCalls, 25, "runtime tool cap retained");
+});
+
+test("applyDefaults remains backward compatible when called directly", () => {
+	const result = applyDefaults({ panel: ["legacy/panel"] }, {});
+	eq(result.panel, ["legacy/panel"], "direct legacy use remains supported");
+});
+
+test("generated config uses a resolvable named default panel", () => {
+	const example = generateConfigExample(["provider/panel"], "provider/judge");
+	eq(example.defaultPanel, "default", "generated config names its default panel");
+	eq(example.panels?.default.models, ["provider/panel"], "generated panel uses resolved models");
+	eq(example.panels?.default.judge, "provider/judge", "generated panel uses resolved judge");
+	const resolved = resolveEffectiveConfig(example);
+	if (!resolved.ok) throw new Error(resolved.error.message);
+	eq(resolved.profileName, "default", "generated config resolves through named-panel path");
+});
+
+test("config parser rejects non-object JSON roots", () => {
+	for (const value of ["null", "[]", '"panel"']) {
+		let error: unknown;
+		try {
+			parseFusionConfig(value);
+		} catch (caught) {
+			error = caught;
+		}
+		if (!(error instanceof Error) || !error.message.includes("JSON object")) {
+			throw new Error(`expected object-root error for ${value}`);
+		}
+	}
+});

--- a/src/__tests__/fusion.test.ts
+++ b/src/__tests__/fusion.test.ts
@@ -2,8 +2,8 @@
  * Tests for pi-fusion pipeline helpers.
  */
 
-import { emptyPanelError } from "../fusion.ts";
-import { eq, test } from "./_harness.ts";
+import { emptyPanelError, resolveFusionSelection, resolvePanelReasoning } from "../fusion.ts";
+import { eq, fakeModel, test } from "./_harness.ts";
 
 test("emptyPanelError treats non-empty content as success", () => {
 	eq(emptyPanelError("a real answer", false), undefined, "normal");
@@ -17,4 +17,128 @@ test("emptyPanelError flags blank/whitespace output as a failure", () => {
 
 test("emptyPanelError attributes a capped empty to the loop guard/budget", () => {
 	eq(emptyPanelError("", true), "no text answer (tool-call budget or loop guard hit)", "capped + empty");
+});
+
+function registryFor(models: ReturnType<typeof fakeModel>[], authed: Set<string> = new Set(models.map((m) => `${m.provider}/${m.id}`))) {
+	return {
+		find(provider: string, id: string) {
+			return models.find((m) => m.provider === provider && m.id === id);
+		},
+		getAll() {
+			return models;
+		},
+		getAvailable() {
+			return models.filter((m) => authed.has(`${m.provider}/${m.id}`));
+		},
+		hasConfiguredAuth(model: ReturnType<typeof fakeModel>) {
+			return authed.has(`${model.provider}/${model.id}`);
+		},
+	} as any;
+}
+
+test("selection preview exposes named panel metadata from the shared boundary", async () => {
+	const named = fakeModel("named", "ready");
+	const result = await resolveFusionSelection(
+		{
+			panels: { quality: { models: ["named/ready"], judge: "named/ready" } },
+			defaultPanel: "quality",
+		},
+		registryFor([named]),
+		undefined,
+		{},
+	);
+
+	if (!result.ok) throw new Error(`unexpected selection failure: ${result.result.details.error}`);
+	eq(result.resolution.profileName, "quality", "preview reports named panel");
+	eq(result.resolution.source, "default", "preview reports default source");
+});
+
+test("one-shot named panel reasoning does not inherit a saved session profile", async () => {
+	const named = fakeModel("named", "ready", { reasoning: true });
+	const result = await resolveFusionSelection(
+		{
+			panelReasoning: "low",
+			judgeReasoning: "medium",
+			panels: {
+				quality: {
+					models: ["named/ready"],
+					judge: "named/ready",
+					panelReasoning: "xhigh",
+				},
+			},
+		},
+		registryFor([named]),
+		undefined,
+		{
+			panel_profile: "quality",
+			panel_reasoning: "minimal",
+			judge_reasoning: "high",
+		},
+	);
+
+	if (!result.ok) throw new Error(`unexpected selection failure: ${result.result.details.error}`);
+	eq(result.config.panelReasoning, "xhigh", "explicit named panel keeps its own panel effort");
+	eq(result.config.judgeReasoning, "medium", "explicit named panel inherits top-level judge effort");
+});
+
+test("strict named panel failure is structured and performs no provider calls", async () => {
+	const locked = fakeModel("named", "locked");
+	let providerCalls = 0;
+	const registry = {
+		...registryFor([locked], new Set()),
+		async getApiKeyAndHeaders() {
+			providerCalls++;
+			return { ok: true, apiKey: "unused" };
+		},
+	} as any;
+
+	const result = await resolveFusionSelection(
+		{ panels: { quality: { models: ["named/locked"] } } },
+		registry,
+		undefined,
+		{ panel_profile: "quality" },
+	);
+
+	if (result.ok) throw new Error("expected strict selection failure");
+	eq(result.result.details.status, "error", "failure is a Fusion error result");
+	eq(result.result.details.panel_profile, "quality", "failure identifies requested panel");
+	eq(result.result.details.responses, [], "failure has no model responses");
+	eq(providerCalls, 0, "strict failure makes no provider calls");
+});
+
+test("zero-auth default falls through to legacy with warnings and no auto substitution", async () => {
+	const locked = fakeModel("named", "locked");
+	const legacy = fakeModel("legacy", "ready");
+	const result = await resolveFusionSelection(
+		{
+			panel: ["legacy/ready"],
+			judge: "legacy/ready",
+			panels: { quality: { models: ["named/locked"] } },
+			defaultPanel: "quality",
+		},
+		registryFor([locked, legacy], new Set(["legacy/ready"])),
+		undefined,
+		{},
+	);
+
+	if (!result.ok) throw new Error(`unexpected selection failure: ${result.result.details.error}`);
+	eq(result.resolution.panel.map((m) => `${m.provider}/${m.id}`), ["legacy/ready"], "legacy panel is recovered");
+	eq(result.resolution.profileName, undefined, "failed default is not reported as active");
+	if (!result.resolution.warnings.some((warning) => warning.includes("quality") && warning.includes("no authed models"))) {
+		throw new Error(`missing default fallback warning: ${result.resolution.warnings.join("; ")}`);
+	}
+});
+
+test("panel reasoning support is resolved deterministically in panel order", () => {
+	const supported = fakeModel("openai", "reasoner", { reasoning: true });
+	const unsupported = fakeModel("plain", "model");
+	const result = resolvePanelReasoning([supported, unsupported], "high");
+
+	eq(result.effective, {
+		"openai/reasoner": "high",
+		"plain/model": null,
+	}, "effective reasoning is recorded per model");
+	eq(result.warnings, [
+		"Reasoning high is not supported by plain/model; running that model without requested reasoning.",
+	], "warnings follow panel order before concurrent calls");
 });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,11 +1,16 @@
 import { test, eq, fakeModel } from "./_harness.ts";
 import registerFusionExtension, {
+	activatePendingPanel,
+	armPendingPanel,
 	buildInitialState,
-	formatExtensionStatusLine,
+	clearPendingPanel,
+	consumePendingPanel,
 	fusionFooterText,
 	normalizeFooterDisplay,
+	parsePanelCommand,
 } from "../index.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { PendingPanelSelection } from "../index.ts";
 
 test("normalizeFooterDisplay accepts known footer modes", () => {
 	eq(normalizeFooterDisplay("full"), "full", "full is accepted");
@@ -18,12 +23,58 @@ test("normalizeFooterDisplay falls back to full", () => {
 	eq(normalizeFooterDisplay("bad"), "full", "invalid footer display falls back");
 });
 
+test("parsePanelCommand consumes only a leading panel option and preserves prompt text", () => {
+	eq(
+		parsePanelCommand("--panel fast explain this  exactly"),
+		{ ok: true, panelName: "fast", prompt: "explain this  exactly" },
+		"leading option parsed",
+	);
+	eq(
+		parsePanelCommand("--panel fast  preserve leading prompt space"),
+		{ ok: true, panelName: "fast", prompt: " preserve leading prompt space" },
+		"only one separator is consumed",
+	);
+	eq(
+		parsePanelCommand("explain --panel fast as text"),
+		{ ok: true, prompt: "explain --panel fast as text" },
+		"non-leading option remains prompt text",
+	);
+});
+
+test("parsePanelCommand rejects missing panel names and prompts", () => {
+	const missingName = parsePanelCommand("--panel");
+	if (missingName.ok) throw new Error("expected missing panel name failure");
+	const missingPrompt = parsePanelCommand("--panel fast");
+	if (missingPrompt.ok) throw new Error("expected missing prompt failure");
+	if (!missingName.error.includes("name")) throw new Error(`unexpected error: ${missingName.error}`);
+	if (!missingPrompt.error.includes("prompt")) throw new Error(`unexpected error: ${missingPrompt.error}`);
+});
+
+test("pending panel is session-bound, agent-bound, and consumed once", () => {
+	let pending: PendingPanelSelection | undefined = armPendingPanel("fast", "session-a");
+	eq(consumePendingPanel(pending, "session-a"), { panelName: undefined, pending }, "not consumed before agent start");
+	pending = activatePendingPanel(pending, "session-a");
+	eq(consumePendingPanel(pending, "session-b"), { panelName: undefined, pending }, "other session cannot consume");
+	eq(consumePendingPanel(pending, "session-a"), { panelName: "fast", pending: undefined }, "matching run consumes once");
+	eq(clearPendingPanel(pending, "session-b"), pending, "other session cannot clear");
+	eq(clearPendingPanel(pending, "session-a"), undefined, "matching session clears");
+});
+
 test("fusionFooterText supports full, compact, and off display modes", () => {
 	const panel = new Set(["anthropic/claude-sonnet-4-5", "openai/gpt-4.1"]);
 	eq(
 		fusionFooterText(panel, "anthropic/claude-opus-4-5", "available", "full"),
 		"Fusion available • 2 panel • judge anthropic/claude-opus-4-5",
 		"full footer includes judge",
+	);
+	eq(
+		fusionFooterText(panel, "anthropic/claude-opus-4-5", "available", "full", {
+			profileName: "quality",
+			panelReasoning: "high",
+			judgeReasoning: "xhigh",
+		}),
+		"Fusion available • named panel quality • 2 panel • panel reasoning high • judge reasoning xhigh • judge anthropic/claude-opus-4-5",
+		"full status uses the canonical profile and reasoning order",
 	);
 	eq(
 		fusionFooterText(panel, "anthropic/claude-opus-4-5", "available", "compact"),
@@ -42,25 +93,6 @@ test("fusionFooterText hides footer text when panel is empty", () => {
 	eq(fusionFooterText(new Set(), undefined, "off", "full"), "Fusion off", "off mode still reports disabled state");
 });
 
-test("formatExtensionStatusLine sorts, sanitizes, and truncates statuses", () => {
-	const statuses = new Map([
-		["z-token-speed", "\x1B[31m⚡\x1B[0m TPS\n42\tfast\x07"],
-		["a-honcho", " Honcho  ready  "],
-	]);
-	eq(
-		formatExtensionStatusLine(statuses, 80),
-		"Honcho ready ⚡ TPS 42 fast",
-		"status text is sorted by key and sanitized",
-	);
-	eq(formatExtensionStatusLine(statuses, 12), "Honcho re...", "status text truncates to footer width");
-	eq(formatExtensionStatusLine(new Map([["empty", "\n\t\x07"]]), 80), undefined, "empty sanitized statuses are omitted");
-	eq(
-		formatExtensionStatusLine(new Map([["link", "\x1B]8;;https://example.com\x07Token\x1B]8;;\x07 ready"]]), 80),
-		"Token ready",
-		"OSC hyperlinks keep visible text without leaking control payload",
-	);
-});
-
 function fakeContext(branch: unknown[] = []): ExtensionContext {
 	return {
 		sessionManager: {
@@ -69,21 +101,24 @@ function fakeContext(branch: unknown[] = []): ExtensionContext {
 	} as ExtensionContext;
 }
 
-test("registered footer refresh appends extension statuses", async () => {
-	type FooterFactory = (tui: unknown, theme: { fg: (_color: string, value: string) => string }, footerData: unknown) => { render(width: number): string[] };
+test("lifecycle refresh publishes and clears only Fusion's keyed status", async () => {
 	type EventHandler = (event: unknown, ctx: ExtensionContext) => unknown | Promise<unknown>;
 
-	let footerFactory: FooterFactory | undefined;
 	const handlers = new Map<string, EventHandler>();
-	const branch = [{
+	let branch: unknown[] = [{
 		type: "custom",
 		customType: "fusion-state",
 		data: {
 			selectedIds: ["anthropic/claude-sonnet-4-5"],
 			judgeId: "anthropic/claude-opus-4-5",
 			footerDisplay: "full",
+			profileName: "quality",
+			panelReasoning: "high",
+			judgeReasoning: "xhigh",
 		},
 	}];
+	const statuses: Array<{ key: string; text: string | undefined }> = [];
+	let footerCalls = 0;
 	const ctx = {
 		cwd: "/tmp/pi-fusion",
 		isProjectTrusted: () => false,
@@ -94,14 +129,13 @@ test("registered footer refresh appends extension statuses", async () => {
 		},
 		sessionManager: {
 			getBranch: () => branch,
-			getEntries: () => [],
-			getSessionName: () => undefined,
 		},
 		ui: {
-			setStatus: () => {},
-			setWidget: () => {},
-			setFooter: (factory: typeof footerFactory) => {
-				footerFactory = factory;
+			setStatus: (key: string, text: string | undefined) => {
+				statuses.push({ key, text });
+			},
+			setFooter: () => {
+				footerCalls++;
 			},
 		},
 	} as unknown as ExtensionContext;
@@ -118,24 +152,22 @@ test("registered footer refresh appends extension statuses", async () => {
 	const refreshFooter = handlers.get("session_start");
 	if (!refreshFooter) throw new Error("expected session_start handler to be registered");
 	await refreshFooter({}, ctx);
-	if (!footerFactory) throw new Error("expected custom footer to be installed");
-
-	const component = footerFactory(
-		{ requestRender: () => {} },
-		{ fg: (_color: string, value: string) => value },
+	eq(
+		statuses.at(-1),
 		{
-			onBranchChange: () => () => {},
-			getGitBranch: () => "feature",
-			getAvailableProviderCount: () => 1,
-			getExtensionStatuses: () => new Map([
-				["z-token-speed", "⚡ TPS 42"],
-				["a-honcho", "Honcho ready"],
-			]),
+			key: "fusion",
+			text: "Fusion available • 1 panel • panel reasoning high • judge reasoning xhigh • judge anthropic/claude-opus-4-5",
 		},
+		"session refresh publishes Fusion status",
 	);
-	const lines = component.render(120);
-	eq(lines.length, 3, "custom footer includes extension status line");
-	eq(lines[2], "Honcho ready ⚡ TPS 42", "extension status line is appended in sorted order");
+	eq(footerCalls, 0, "Fusion never replaces Pi's footer renderer");
+
+	branch = [];
+	const refreshTree = handlers.get("session_tree");
+	if (!refreshTree) throw new Error("expected session_tree handler to be registered");
+	await refreshTree({}, ctx);
+	eq(statuses.at(-1), { key: "fusion", text: undefined }, "missing state clears stale Fusion status");
+	eq(footerCalls, 0, "clearing status does not replace Pi's footer renderer");
 });
 
 test("buildInitialState seeds panel tools from config when session has no tool choice", () => {
@@ -184,4 +216,41 @@ test("buildInitialState prefers session footer display over config", () => {
 		"full",
 	);
 	eq(state.footerDisplay, "off", "session footerDisplay wins");
+});
+
+test("buildInitialState uses configured status display when an older session has no override", () => {
+	const state = buildInitialState(
+		fakeContext([{
+			type: "custom",
+			customType: "fusion-state",
+			data: {
+				selectedIds: ["anthropic/claude-sonnet-4-5"],
+			},
+		}]),
+		[{ display: "anthropic/claude-sonnet-4-5" }],
+		{ display: "anthropic/claude-opus-4-5" },
+		"none",
+		"off",
+	);
+	eq(state.footerDisplay, "off", "missing session value does not override configured status display");
+});
+
+test("buildInitialState restores reasoning as a custom session snapshot", () => {
+	const state = buildInitialState(
+		fakeContext([{
+			type: "custom",
+			customType: "fusion-state",
+			data: {
+				selectedIds: ["openai/gpt-5.5"],
+				judgeId: "openai/gpt-5.5",
+				panelReasoning: "high",
+				judgeReasoning: "xhigh",
+			},
+		}]),
+		[{ display: "legacy/model" }],
+		{ display: "legacy/judge" },
+	);
+	eq(state.profileName, undefined, "saved session is treated as a detached custom snapshot");
+	eq(state.panelReasoning, "high", "panel effort restored");
+	eq(state.judgeReasoning, "xhigh", "judge effort restored");
 });

--- a/src/__tests__/llm.test.ts
+++ b/src/__tests__/llm.test.ts
@@ -2,9 +2,10 @@
  * Tests for provider/model request compatibility.
  */
 
-import { getSupportsTemperature } from "../llm.ts";
-import type { Api, Model } from "../types.ts";
-import { fakeModel, test } from "./_harness.ts";
+import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai";
+import { buildCompleteOptions, callModelWithTools, getSupportsTemperature, resolveModelReasoning } from "../llm.ts";
+import type { Api, Model, ThinkingLevel } from "../types.ts";
+import { eq, fakeModel, test } from "./_harness.ts";
 
 test("openai-codex provider rejects temperature even when id does not contain codex", () => {
 	const model = fakeModel("openai-codex", "gpt-5.5");
@@ -28,4 +29,79 @@ test("anthropic model without a compat flag defaults to supporting temperature",
 test("ordinary openai-compatible model keeps temperature", () => {
 	const model = fakeModel("openai", "gpt-4.1");
 	if (!getSupportsTemperature(model)) throw new Error("expected regular model to support temperature");
+});
+
+test("resolveModelReasoning preserves supported effort and omits unsupported effort", () => {
+	const supported = fakeModel("openai", "reasoner", {
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+	});
+	const unsupported = fakeModel("openai", "plain");
+
+	eq(resolveModelReasoning(supported, "xhigh"), { requested: "xhigh", effective: "xhigh" }, "supported xhigh");
+	eq(resolveModelReasoning(unsupported, "high"), {
+		requested: "high",
+		warning: "Reasoning high is not supported by openai/plain; running that model without requested reasoning.",
+	}, "unsupported reasoning is omitted with a model-specific warning");
+	eq(resolveModelReasoning(supported, undefined), {}, "unset reasoning is unchanged");
+});
+
+test("completion options preserve token and temperature inputs while adding reasoning", async () => {
+	const model = fakeModel("openai", "reasoner", { reasoning: true });
+	const options = await buildCompleteOptions({
+		async getApiKeyAndHeaders() {
+			return { ok: true, apiKey: "test", headers: { "x-test": "yes" } };
+		},
+	} as any, model, 2048, 0.3, undefined, "high");
+
+	eq(options.maxTokens, 2048, "token cap input is unchanged");
+	eq(options.temperature, 0.3, "temperature input is unchanged");
+	eq(options.reasoning, "high", "supported reasoning is attached");
+});
+
+test("tool-loop finalization reuses reasoning on every raw completion", async () => {
+	const registration = registerFauxProvider({
+		api: `fusion-reasoning-${Date.now()}`,
+		provider: "fusion-test",
+		models: [{ id: "reasoner", reasoning: true }],
+	});
+	const seen: Array<ThinkingLevel | undefined> = [];
+	const toolEvents: string[] = [];
+	registration.setResponses([
+		(_context, options) => {
+			seen.push((options as { reasoning?: ThinkingLevel } | undefined)?.reasoning);
+			return fauxAssistantMessage(fauxToolCall("probe", {}), { stopReason: "toolUse" });
+		},
+		(_context, options) => {
+			seen.push((options as { reasoning?: ThinkingLevel } | undefined)?.reasoning);
+			return fauxAssistantMessage("final answer");
+		},
+	]);
+
+	try {
+		await callModelWithTools(
+			{ async getApiKeyAndHeaders() { return { ok: true, apiKey: "test" }; } } as any,
+			registration.getModel() as Model<Api>,
+			"system",
+			"task",
+			2048,
+			0.3,
+			undefined,
+			[{
+				name: "probe",
+				description: "probe",
+				parameters: { type: "object", properties: {} },
+				async execute() { return { content: [{ type: "text", text: "ok" }], details: {} }; },
+			}] as any,
+			1,
+			{} as any,
+			(event) => toolEvents.push(event.name),
+			"high",
+		);
+	} finally {
+		registration.unregister();
+	}
+
+	eq(seen, ["high", "high"], "initial and forced-final completions share reasoning");
+	eq(toolEvents, ["probe"], "existing callback position remains compatible");
 });

--- a/src/__tests__/models.test.ts
+++ b/src/__tests__/models.test.ts
@@ -2,8 +2,8 @@
  * Tests for pi-fusion model resolution and panel selection.
  */
 
-import { modelDisplay, resolvePanelAndJudge, selectDiversePanel } from "../models.ts";
-import { fakeModel, test } from "./_harness.ts";
+import { modelDisplay, PanelSelectionError, resolvePanelAndJudge, selectDiversePanel } from "../models.ts";
+import { eq, fakeModel, test } from "./_harness.ts";
 
 test("modelDisplay formats provider/id", () => {
 	const display = modelDisplay(fakeModel("anthropic", "claude-sonnet-4-5"));
@@ -80,4 +80,127 @@ test("auto panel still defaults to 3 models", async () => {
 
 	const result = await resolvePanelAndJudge(registry, {});
 	if (result.panel.length !== 3) throw new Error(`expected auto panel default 3, got ${result.panel.length}`);
+});
+
+test("partially authed named default remains the selected candidate", async () => {
+	const models = [fakeModel("named", "ready"), fakeModel("named", "locked"), fakeModel("legacy", "fallback")];
+	const registry = {
+		find(provider: string, id: string) {
+			return models.find((m) => m.provider === provider && m.id === id);
+		},
+		getAll() {
+			return models;
+		},
+		getAvailable() {
+			return models.filter((m) => m.id !== "locked");
+		},
+		hasConfiguredAuth(model: (typeof models)[number]) {
+			return model.id !== "locked";
+		},
+	} as any;
+
+	const result = await resolvePanelAndJudge(registry, {
+		candidates: [
+			{
+				source: "default",
+				profileName: "quality",
+				panel: ["named/ready", "named/locked"],
+				judge: "named/ready",
+				maxPanelModels: 3,
+			},
+			{ source: "legacy", panel: ["legacy/fallback"], maxPanelModels: 3 },
+		],
+	});
+
+	eq(result.panel.map(modelDisplay), ["named/ready"], "partial named panel is retained");
+	eq(result.source, "default", "named default remains the source");
+	eq(result.profileName, "quality", "named panel metadata is retained");
+});
+
+test("zero-auth named default retries legacy before auto selection", async () => {
+	const models = [fakeModel("named", "locked"), fakeModel("legacy", "ready"), fakeModel("auto", "other")];
+	let autoReads = 0;
+	const registry = {
+		find(provider: string, id: string) {
+			return models.find((m) => m.provider === provider && m.id === id);
+		},
+		getAll() {
+			return models;
+		},
+		getAvailable() {
+			autoReads++;
+			return models.filter((m) => m.id !== "locked");
+		},
+		hasConfiguredAuth(model: (typeof models)[number]) {
+			return model.id !== "locked";
+		},
+	} as any;
+
+	const result = await resolvePanelAndJudge(registry, {
+		candidates: [
+			{ source: "default", profileName: "quality", panel: ["named/locked"], maxPanelModels: 3 },
+			{ source: "legacy", panel: ["legacy/ready"], maxPanelModels: 3 },
+		],
+	});
+
+	eq(result.panel.map(modelDisplay), ["legacy/ready"], "legacy panel wins before auto");
+	eq(result.source, "legacy", "legacy source is reported");
+	eq(autoReads, 0, "auto selection is not consulted after legacy succeeds");
+});
+
+test("session panel without a judge falls back to the configured judge", async () => {
+	const panel = fakeModel("session", "panel");
+	const judge = fakeModel("config", "judge");
+	const models = [panel, judge];
+	const registry = {
+		find(provider: string, id: string) {
+			return models.find((model) => model.provider === provider && model.id === id);
+		},
+		getAll: () => models,
+		getAvailable: () => models,
+		hasConfiguredAuth: () => true,
+	} as any;
+
+	const result = await resolvePanelAndJudge(registry, {
+		candidates: [{ source: "session", panel: ["session/panel"], maxPanelModels: 8 }],
+		autoJudge: "config/judge",
+	});
+
+	eq(modelDisplay(result.judge), "config/judge", "legacy session-to-config judge fallback is preserved");
+});
+
+test("strict zero-auth named panel stops without reading fallback models", async () => {
+	const model = fakeModel("named", "locked");
+	let autoReads = 0;
+	const registry = {
+		find() {
+			return model;
+		},
+		getAll() {
+			return [model];
+		},
+		getAvailable() {
+			autoReads++;
+			return [model];
+		},
+		hasConfiguredAuth() {
+			return false;
+		},
+	} as any;
+
+	let error: unknown;
+	try {
+		await resolvePanelAndJudge(registry, {
+			candidates: [
+				{ source: "explicit", profileName: "quality", panel: ["named/locked"], maxPanelModels: 3, strict: true },
+				{ source: "legacy", panel: ["named/locked"], maxPanelModels: 3 },
+			],
+		});
+	} catch (caught) {
+		error = caught;
+	}
+
+	if (!(error instanceof PanelSelectionError)) throw new Error("expected a strict panel selection error");
+	eq(error.profileName, "quality", "strict error identifies the named panel");
+	eq(autoReads, 0, "strict failure never reaches auto selection");
 });

--- a/src/__tests__/ui.test.ts
+++ b/src/__tests__/ui.test.ts
@@ -2,7 +2,14 @@
  * Tests for pi-fusion setup picker selection helpers (independent panel + judge).
  */
 
-import { modelBadges, togglePanelMember, toggleJudgeSelection } from "../ui.ts";
+import {
+	applySetupProfile,
+	markSetupCustom,
+	modelBadges,
+	togglePanelMember,
+	toggleJudgeSelection,
+} from "../ui.ts";
+import type { FusionSetupState } from "../ui.ts";
 import { eq, test } from "./_harness.ts";
 
 test("togglePanelMember adds and removes", () => {
@@ -48,4 +55,38 @@ test("modelBadges reflects panel/judge state (right-column format)", () => {
 	eq(modelBadges(true, false), "● panel", "panel only");
 	eq(modelBadges(false, true), "◆ judge", "judge only");
 	eq(modelBadges(true, true), "● panel  ◆ judge", "both");
+});
+
+test("applySetupProfile copies a frozen model, judge, and reasoning snapshot", () => {
+	const state: FusionSetupState = {
+		selectedIds: new Set(["legacy/model"]),
+		judgeId: "legacy/judge",
+		profiles: {
+			quality: {
+				selectedIds: ["openai/gpt-5.5", "anthropic/claude-sonnet-5"],
+				judgeId: "openai/gpt-5.5",
+				panelReasoning: "high" as const,
+				judgeReasoning: "xhigh" as const,
+			},
+		},
+	};
+	applySetupProfile(state, "quality");
+	eq([...state.selectedIds], ["openai/gpt-5.5", "anthropic/claude-sonnet-5"], "models copied");
+	eq(state.judgeId, "openai/gpt-5.5", "judge copied");
+	eq(state.panelReasoning, "high", "panel reasoning copied");
+	eq(state.judgeReasoning, "xhigh", "judge reasoning copied");
+	eq(state.profileName, "quality", "profile provenance set");
+
+	state.profiles!.quality.selectedIds.push("later/config-edit");
+	eq([...state.selectedIds], ["openai/gpt-5.5", "anthropic/claude-sonnet-5"], "snapshot is frozen");
+});
+
+test("profile-owned edits mark setup custom while unrelated config can retain provenance", () => {
+	const state = {
+		selectedIds: new Set(["openai/gpt-5.5"]),
+		judgeId: "openai/gpt-5.5",
+		profileName: "quality",
+	};
+	markSetupCustom(state);
+	eq(state.profileName, undefined, "profile-owned edit clears provenance");
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,14 @@
 import { getAgentDir } from "@earendil-works/pi-coding-agent";
 import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
-import type { FusionConfig, ResolvedFusionConfig } from "./types.ts";
+import type {
+	ConfigSelectionError,
+	EffectiveConfigResult,
+	FusionConfig,
+	NamedPanelConfig,
+	ResolvedFusionConfig,
+	ThinkingLevel,
+} from "./types.ts";
 
 export type { FusionConfig, ResolvedFusionConfig };
 
@@ -22,6 +29,17 @@ export const MAX_TOOL_CALLS = 100;
 /** Per tool result, before it re-enters the loop transcript (keeps panel context bounded). */
 export const TOOL_OUTPUT_MAX_BYTES = 12_000;
 
+export const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
+
+export interface FusionConfigOverrides {
+	max_completion_tokens?: number;
+	temperature?: number;
+	panel_tools?: FusionConfig["panelTools"];
+	max_tool_calls?: number;
+	panel_reasoning?: ThinkingLevel;
+	judge_reasoning?: ThinkingLevel;
+}
+
 export function loadConfig(cwd: string, projectTrusted: boolean): FusionConfig {
 	const paths: string[] = [];
 	if (projectTrusted) {
@@ -32,7 +50,7 @@ export function loadConfig(cwd: string, projectTrusted: boolean): FusionConfig {
 	for (const path of paths) {
 		if (!existsSync(path)) continue;
 		try {
-			return JSON.parse(readFileSync(path, "utf8")) as FusionConfig;
+			return parseFusionConfig(readFileSync(path, "utf8"));
 		} catch (err) {
 			console.error(`[pi-fusion] failed to parse ${path}:`, err);
 		}
@@ -40,18 +58,21 @@ export function loadConfig(cwd: string, projectTrusted: boolean): FusionConfig {
 	return {};
 }
 
-export function applyDefaults(config: FusionConfig, overrides: {
-	max_completion_tokens?: number;
-	temperature?: number;
-	panel_tools?: FusionConfig["panelTools"];
-	max_tool_calls?: number;
-}): ResolvedFusionConfig {
+export function parseFusionConfig(text: string): FusionConfig {
+	const parsed: unknown = JSON.parse(text);
+	if (!isRecord(parsed)) throw new Error("Fusion config root must be a JSON object.");
+	return parsed as FusionConfig;
+}
+
+export function applyDefaults(config: FusionConfig, overrides: FusionConfigOverrides): ResolvedFusionConfig {
 	const merged: FusionConfig = {
 		...config,
 		...(overrides.max_completion_tokens ? { maxCompletionTokens: overrides.max_completion_tokens } : {}),
 		...(overrides.temperature !== undefined ? { temperature: overrides.temperature } : {}),
 		...(overrides.panel_tools !== undefined ? { panelTools: overrides.panel_tools } : {}),
 		...(overrides.max_tool_calls !== undefined ? { maxToolCalls: overrides.max_tool_calls } : {}),
+		...(overrides.panel_reasoning !== undefined ? { panelReasoning: overrides.panel_reasoning } : {}),
+		...(overrides.judge_reasoning !== undefined ? { judgeReasoning: overrides.judge_reasoning } : {}),
 	};
 	// Single source of truth for defaults: callers can read these numeric knobs directly.
 	return {
@@ -64,14 +85,170 @@ export function applyDefaults(config: FusionConfig, overrides: {
 	};
 }
 
+/**
+ * Select and normalize user-owned panel config before model/auth resolution.
+ * Explicit selections fail closed; invalid configured defaults warn and retain
+ * the legacy config so the model resolver can continue to legacy/auto selection.
+ */
+export function resolveEffectiveConfig(
+	config: FusionConfig,
+	overrides: FusionConfigOverrides = {},
+	explicitPanel?: string,
+): EffectiveConfigResult {
+	const warnings: string[] = [];
+	const normalized = normalizeTopLevelReasoning(config, warnings);
+
+	if (explicitPanel !== undefined) {
+		const selected = readNamedPanel(normalized, explicitPanel);
+		if (!selected.ok) return { ok: false, error: selected.error, warnings };
+		return {
+			ok: true,
+			config: applyDefaults(applyNamedPanel(normalized, selected.panel), overrides),
+			profileName: explicitPanel,
+			source: "explicit",
+			warnings,
+		};
+	}
+
+	const rawDefault = (normalized as { defaultPanel?: unknown }).defaultPanel;
+	if (rawDefault !== undefined) {
+		if (typeof rawDefault !== "string" || rawDefault.trim().length === 0) {
+			warnings.push("Configured defaultPanel must be a non-empty string; falling back to legacy or auto selection.");
+		} else {
+			const selected = readNamedPanel(normalized, rawDefault);
+			if (selected.ok) {
+				return {
+					ok: true,
+					config: applyDefaults(applyNamedPanel(normalized, selected.panel), overrides),
+					profileName: rawDefault,
+					source: "default",
+					warnings,
+				};
+			}
+			warnings.push(
+				`Configured defaultPanel "${rawDefault}" is invalid: ${selected.error.message} Falling back to legacy or auto selection.`,
+			);
+		}
+	}
+
+	return {
+		ok: true,
+		config: applyDefaults(normalized, overrides),
+		source: "legacy",
+		warnings,
+	};
+}
+
+function normalizeTopLevelReasoning(config: FusionConfig, warnings: string[]): FusionConfig {
+	const normalized = { ...config };
+	for (const key of ["panelReasoning", "judgeReasoning"] as const) {
+		const value = (config as Record<string, unknown>)[key];
+		if (value !== undefined && !isThinkingLevel(value)) {
+			delete normalized[key];
+			warnings.push(
+				`Invalid ${key} value; omitting it. Expected ${THINKING_LEVELS.join(", ")}.`,
+			);
+		}
+	}
+	return normalized;
+}
+
+function readNamedPanel(
+	config: FusionConfig,
+	panelName: string,
+): { ok: true; panel: NamedPanelConfig } | { ok: false; error: ConfigSelectionError } {
+	if (!panelName.trim()) {
+		return invalidPanel(panelName, "Named panel name must be a non-empty string.");
+	}
+
+	const panels = (config as { panels?: unknown }).panels;
+	if (!isRecord(panels) || !Object.hasOwn(panels, panelName)) {
+		return {
+			ok: false,
+			error: {
+				code: "unknown_named_panel",
+				panelName,
+				message: `Named panel "${panelName}" is not configured.`,
+			},
+		};
+	}
+
+	const value = panels[panelName];
+	if (!isRecord(value)) {
+		return invalidPanel(panelName, `Named panel "${panelName}" must be an object.`);
+	}
+	if (!Array.isArray(value.models) || value.models.length === 0) {
+		return invalidPanel(panelName, `Named panel "${panelName}" must define at least one model.`);
+	}
+	if (!value.models.every((model) => typeof model === "string" && model.trim().length > 0)) {
+		return invalidPanel(panelName, `Named panel "${panelName}" models must be non-empty strings.`);
+	}
+	if (value.judge !== undefined && (typeof value.judge !== "string" || value.judge.trim().length === 0)) {
+		return invalidPanel(panelName, `Named panel "${panelName}" judge must be a non-empty string.`);
+	}
+	for (const key of ["panelReasoning", "judgeReasoning"] as const) {
+		if (value[key] !== undefined && !isThinkingLevel(value[key])) {
+			return invalidPanel(
+				panelName,
+				`Named panel "${panelName}" ${key} must be one of ${THINKING_LEVELS.join(", ")}.`,
+			);
+		}
+	}
+
+	return {
+		ok: true,
+		panel: {
+			models: [...value.models] as string[],
+			...(value.judge !== undefined ? { judge: value.judge as string } : {}),
+			...(value.panelReasoning !== undefined ? { panelReasoning: value.panelReasoning as ThinkingLevel } : {}),
+			...(value.judgeReasoning !== undefined ? { judgeReasoning: value.judgeReasoning as ThinkingLevel } : {}),
+		},
+	};
+}
+
+function applyNamedPanel(config: FusionConfig, panel: NamedPanelConfig): FusionConfig {
+	return {
+		...config,
+		panel: [...panel.models],
+		judge: panel.judge ?? config.judge,
+		panelReasoning: panel.panelReasoning ?? config.panelReasoning,
+		judgeReasoning: panel.judgeReasoning ?? config.judgeReasoning,
+	};
+}
+
+function invalidPanel(
+	panelName: string,
+	message: string,
+): { ok: false; error: ConfigSelectionError } {
+	return {
+		ok: false,
+		error: { code: "invalid_named_panel", panelName, message },
+	};
+}
+
+function isThinkingLevel(value: unknown): value is ThinkingLevel {
+	return typeof value === "string" && (THINKING_LEVELS as readonly string[]).includes(value);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
 export function generateConfigExample(panel?: string[], judge?: string): FusionConfig {
 	return {
-		panel: panel ?? [
-			"anthropic/claude-sonnet-4-5",
-			"openai/gpt-4.1",
-			"google/gemini-2.5-pro",
-		],
-		judge: judge ?? "anthropic/claude-opus-4-5",
+		defaultPanel: "default",
+		panels: {
+			default: {
+				models: panel ?? [
+					"anthropic/claude-sonnet-4-5",
+					"openai/gpt-4.1",
+					"google/gemini-2.5-pro",
+				],
+				judge: judge ?? "anthropic/claude-opus-4-5",
+				panelReasoning: "medium",
+				judgeReasoning: "high",
+			},
+		},
 		maxPanelModels: DEFAULT_MAX_PANEL_MODELS,
 		maxPanelOutputTokens: DEFAULT_MAX_PANEL_OUTPUT_TOKENS,
 		maxCompletionTokens: DEFAULT_MAX_COMPLETION_TOKENS,

--- a/src/fusion.ts
+++ b/src/fusion.ts
@@ -5,14 +5,25 @@
 import type { Api, Model } from "@earendil-works/pi-ai";
 import type { ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import {
-	applyDefaults,
 	loadConfig,
 	PANEL_CONCURRENCY,
+	resolveEffectiveConfig,
 	type ResolvedFusionConfig,
 } from "./config.ts";
 import { buildFusionTaskText } from "./context.ts";
-import { callModelText, callModelWithTools, getTextContent } from "./llm.ts";
-import { modelDisplay, type ResolveOptions, resolvePanelAndJudge, type ResolveResult } from "./models.ts";
+import {
+	callModelText,
+	callModelWithTools,
+	getTextContent,
+	resolveModelReasoning,
+} from "./llm.ts";
+import {
+	modelDisplay,
+	PanelSelectionError,
+	type ResolveCandidate,
+	resolvePanelAndJudge,
+	type ResolveResult,
+} from "./models.ts";
 import { JUDGE_SYSTEM_PROMPT, PANEL_SYSTEM_PROMPT, PANEL_SYSTEM_PROMPT_WITH_TOOLS, truncateForJudge } from "./prompts.ts";
 import {
 	clampMaxToolCalls,
@@ -23,7 +34,17 @@ import {
 	selectionToNames,
 } from "./tools.ts";
 import { extractJson, mapWithConcurrencyLimit } from "./utils.ts";
-import type { FusionAnalysis, FusionDetails, FusionOptions, FusionResult, PanelResult, PanelToolUsage, ToolSelection } from "./types.ts";
+import type {
+	FusionAnalysis,
+	FusionConfig,
+	FusionDetails,
+	FusionOptions,
+	FusionResult,
+	PanelResult,
+	PanelToolUsage,
+	ThinkingLevel,
+	ToolSelection,
+} from "./types.ts";
 
 /**
  * Classify a panel's final text. Blank output (a model that gathered tools but never
@@ -35,20 +56,135 @@ export function emptyPanelError(content: string, capped: boolean): string | unde
 	return capped ? "no text answer (tool-call budget or loop guard hit)" : "empty response";
 }
 
-/** Build the panel/judge resolution options shared by resolveFusionModels and runFusion. */
-function buildResolveOptions(
-	config: ResolvedFusionConfig,
-	overrides: FusionOptions,
+export interface PanelReasoningPlan {
+	requested?: ThinkingLevel;
+	effective: Record<string, ThinkingLevel | null>;
+	warnings: string[];
+}
+
+/** Resolve all panel support before concurrency so warnings and diagnostics are stable. */
+export function resolvePanelReasoning(
+	panel: Model<Api>[],
+	requested: ThinkingLevel | undefined,
+): PanelReasoningPlan {
+	const effective: Record<string, ThinkingLevel | null> = {};
+	const warnings: string[] = [];
+	for (const model of panel) {
+		const name = modelDisplay(model);
+		const resolution = resolveModelReasoning(model, requested);
+		effective[name] = resolution.effective ?? null;
+		if (resolution.warning) warnings.push(resolution.warning);
+	}
+	return { requested, effective, warnings };
+}
+
+export type FusionSelectionResult =
+	| { ok: true; config: ResolvedFusionConfig; resolution: ResolveResult }
+	| { ok: false; result: FusionResult };
+
+/**
+ * Shared config -> candidate -> auth resolution boundary for previews and execution.
+ * Named one-shot selection is internal extension state, not a registered tool input.
+ */
+export async function resolveFusionSelection(
+	rawConfig: FusionConfig,
+	registry: ModelRegistry,
 	currentModel: Model<Api> | undefined,
-): ResolveOptions {
-	return {
-		sessionPanel: overrides.analysis_models,
-		sessionJudge: overrides.model ?? overrides.judge_model,
-		configPanel: config.panel,
-		configJudge: config.judge,
-		configMaxPanelModels: config.maxPanelModels,
-		currentModel,
+	overrides: FusionOptions,
+): Promise<FusionSelectionResult> {
+	const explicitProfile = overrides.panel_profile;
+	// A one-shot named panel owns its model, judge, and reasoning snapshot. Keep
+	// shared runtime overrides, but do not let a previously saved session profile's
+	// reasoning leak into the explicit selection.
+	const effectiveOverrides = explicitProfile
+		? { ...overrides, panel_reasoning: undefined, judge_reasoning: undefined }
+		: overrides;
+	const effective = resolveEffectiveConfig(rawConfig, effectiveOverrides, explicitProfile);
+	if (!effective.ok) {
+		return selectionFailure(effective.error.message, effective.error.panelName, effective.warnings);
+	}
+
+	// Only a valid named default needs a separately normalized legacy fallback.
+	// Explicit profiles fail closed, and legacy selections can reuse their result.
+	let legacyResult: ReturnType<typeof resolveEffectiveConfig> = effective;
+	if (effective.source === "default") {
+		const legacyRaw = { ...rawConfig };
+		delete legacyRaw.defaultPanel;
+		legacyResult = resolveEffectiveConfig(legacyRaw, overrides);
+	}
+	if (!legacyResult.ok) {
+		return selectionFailure(legacyResult.error.message, legacyResult.error.panelName, legacyResult.warnings);
+	}
+	const legacy = legacyResult;
+
+	const candidates: ResolveCandidate[] = [];
+	if (explicitProfile) {
+		candidates.push({
+			source: "explicit",
+			profileName: effective.profileName,
+			panel: effective.config.panel ?? [],
+			judge: effective.config.judge,
+			maxPanelModels: effective.config.maxPanelModels,
+			strict: true,
+		});
+	} else {
+		if (overrides.analysis_models?.length) {
+			candidates.push({
+				source: "session",
+				panel: overrides.analysis_models,
+				judge: overrides.model ?? overrides.judge_model,
+				maxPanelModels: 8,
+			});
+		}
+		if (effective.source === "default") {
+			candidates.push({
+				source: "default",
+				profileName: effective.profileName,
+				panel: effective.config.panel ?? [],
+				judge: effective.config.judge,
+				maxPanelModels: effective.config.maxPanelModels,
+			});
+		}
+		if (legacy.config.panel?.length) {
+			candidates.push({
+				source: "legacy",
+				panel: legacy.config.panel,
+				judge: legacy.config.judge,
+				maxPanelModels: legacy.config.maxPanelModels,
+			});
+		}
+	}
+
+	try {
+		const resolution = await resolvePanelAndJudge(registry, {
+			candidates,
+			autoJudge: legacy.config.judge,
+			autoMaxPanelModels: legacy.config.maxPanelModels,
+			currentModel,
+			warnings: effective.warnings,
+		});
+		const config = resolution.source === "explicit" || resolution.source === "default"
+			? effective.config
+			: legacy.config;
+		return { ok: true, config, resolution };
+	} catch (error) {
+		if (error instanceof PanelSelectionError) {
+			return selectionFailure(error.message, error.profileName, error.warnings);
+		}
+		throw error;
+	}
+}
+
+function selectionFailure(message: string, profileName: string | undefined, warnings: string[]): FusionSelectionResult {
+	const details: FusionDetails = {
+		status: "error",
+		responses: [],
+		...(profileName ? { panel_profile: profileName } : {}),
+		...(warnings.length ? { warnings } : {}),
+		error: message,
+		failure_reason: "unexpected_error",
 	};
+	return { ok: false, result: { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details } };
 }
 
 export async function resolveFusionModels(
@@ -58,8 +194,9 @@ export async function resolveFusionModels(
 	projectTrusted: boolean,
 	overrides: FusionOptions,
 ): Promise<ResolveResult> {
-	const config = applyDefaults(loadConfig(cwd, projectTrusted), overrides);
-	return resolvePanelAndJudge(registry, buildResolveOptions(config, overrides, currentModel));
+	const selection = await resolveFusionSelection(loadConfig(cwd, projectTrusted), registry, currentModel, overrides);
+	if (!selection.ok) throw new Error(selection.result.details.error ?? "Fusion model selection failed");
+	return selection.resolution;
 }
 
 export async function runFusion(
@@ -74,17 +211,27 @@ export async function runFusion(
 	signal: AbortSignal | undefined,
 	onUpdate?: (partial: { content: Array<{ type: "text"; text: string }>; details: unknown }) => void,
 ): Promise<FusionResult> {
-	const config = applyDefaults(loadConfig(cwd, projectTrusted), overrides);
+	const selection = await resolveFusionSelection(loadConfig(cwd, projectTrusted), registry, currentModel, overrides);
+	if (!selection.ok) return selection.result;
+	const { config, resolution } = selection;
 
 	const maxPanelOutputTokens = config.maxPanelOutputTokens;
 	const maxCompletionTokens = config.maxCompletionTokens;
 	const temperature = config.temperature;
 	const taskText = buildFusionTaskText(prompt, overrides.context_text);
 
-	const { panel, judge, warnings } = await resolvePanelAndJudge(
-		registry,
-		buildResolveOptions(config, overrides, currentModel),
-	);
+	const { panel, judge, warnings, profileName, source } = resolution;
+	const requestedPanelReasoning = source === "session"
+		? overrides.panel_reasoning ?? config.panelReasoning
+		: config.panelReasoning;
+	const requestedJudgeReasoning = source === "session"
+		? overrides.judge_reasoning ?? config.judgeReasoning
+		: config.judgeReasoning;
+	const panelReasoning = resolvePanelReasoning(panel, requestedPanelReasoning);
+	warnings.push(...panelReasoning.warnings);
+	const panelReasoningDetails = panelReasoning.requested
+		? { requested: panelReasoning.requested, effective: panelReasoning.effective }
+		: undefined;
 
 	// Resolve panel tools. Fail-closed: mutating tools without consent are stripped
 	// to the read-only subset. Mutating runs serialize the panel (concurrency 1).
@@ -106,20 +253,25 @@ export async function runFusion(
 	const panelModelNames = panel.map(modelDisplay);
 	const judgeName = modelDisplay(judge);
 	const toolsLabel = toolsEnabled ? ` | tools: ${selectionLabel(toolSelection)}·${maxToolCalls}${mutating ? " (serialized)" : ""}` : "";
+	const panelReasoningLabel = panelReasoningDetails
+		? ` | panel reasoning: ${panelReasoningDetails.requested} (${Object.entries(panelReasoningDetails.effective).map(([name, level]) => `${name}=${level ?? "off"}`).join(", ")})`
+		: "";
+	const judgeReasoningLabel = requestedJudgeReasoning ? ` | judge reasoning requested: ${requestedJudgeReasoning}` : "";
 
 	onUpdate?.({
 		content: [
 			{
 				type: "text",
-				text: `Fusion panel: ${panelModelNames.join(", ")} | judge: ${judgeName}${toolsLabel}${warnings.length > 0 ? " | warnings: " + warnings.join("; ") : ""}`,
+				text: `Fusion panel: ${panelModelNames.join(", ")} | judge: ${judgeName}${profileName ? ` | named panel: ${profileName}` : ""}${panelReasoningLabel}${judgeReasoningLabel}${toolsLabel}${warnings.length > 0 ? " | warnings: " + warnings.join("; ") : ""}`,
 			},
 		],
-		details: { phase: "resolving" },
+		details: { phase: "resolving", panel_profile: profileName, panel_reasoning: panelReasoningDetails },
 	});
 
 	// Run panel (serialized when mutating tools are active).
 	const rawPanelResults = await mapWithConcurrencyLimit(panel, panelConcurrency, async (model): Promise<PanelResult> => {
 		const base = { model: modelDisplay(model), provider: model.provider, id: model.id };
+		const effectiveReasoning = panelReasoning.effective[base.model] ?? undefined;
 		try {
 			let content: string;
 			let tools: PanelToolUsage | undefined;
@@ -135,11 +287,13 @@ export async function runFusion(
 					toolDefs,
 					maxToolCalls,
 					ctx,
+					undefined,
+					effectiveReasoning,
 				);
 				content = getTextContent(result.message);
 				tools = { turns: result.turns, tool_calls: result.toolCalls, capped: result.cappedOut };
 			} else {
-				const response = await callModelText(registry, model, PANEL_SYSTEM_PROMPT, taskText, maxPanelOutputTokens, temperature, signal);
+				const response = await callModelText(registry, model, PANEL_SYSTEM_PROMPT, taskText, maxPanelOutputTokens, temperature, signal, effectiveReasoning);
 				content = getTextContent(response);
 			}
 			// Empty output is a failure, not a blank "success" — keep it out of the judge.
@@ -161,6 +315,8 @@ export async function runFusion(
 			failed_models: failed.map((f) => ({ model: f.model, error: f.error ?? "unknown error", ...(f.tools ? { tools: f.tools } : {}) })),
 			panel_models: panelModelNames,
 			judge_model: judgeName,
+			...(profileName ? { panel_profile: profileName } : {}),
+			...(panelReasoningDetails ? { panel_reasoning: panelReasoningDetails } : {}),
 			...(warnings.length > 0 ? { warnings } : {}),
 			error: "all panel models failed",
 			failure_reason: classifyAllPanelFailure(failed),
@@ -178,11 +334,20 @@ export async function runFusion(
 						: `Panel complete (${successful.length}/${panel.length}). Running judge...`,
 			},
 		],
-		details: { phase: successful.length === 1 ? "single_response" : "judging" },
+		details: { phase: successful.length === 1 ? "single_response" : "judging", panel_reasoning: panelReasoningDetails },
 	});
 
 	let analysis: FusionAnalysis | undefined;
+	let judgeReasoningDetails: FusionDetails["judge_reasoning"];
 	if (successful.length >= 2) {
+		const judgeReasoning = resolveModelReasoning(judge, requestedJudgeReasoning);
+		if (judgeReasoning.warning) warnings.push(judgeReasoning.warning);
+		if (judgeReasoning.requested) {
+			judgeReasoningDetails = {
+				requested: judgeReasoning.requested,
+				effective: judgeReasoning.effective ?? null,
+			};
+		}
 		// Run judge.
 		const judgeBudgetPerResponse = Math.max(
 			1024,
@@ -206,6 +371,7 @@ export async function runFusion(
 				maxCompletionTokens,
 				temperature,
 				signal,
+				judgeReasoning.effective,
 			);
 			const judgeText = getTextContent(judgeResponse);
 			analysis = extractJson<FusionAnalysis>(judgeText);
@@ -224,6 +390,9 @@ export async function runFusion(
 			: {}),
 		panel_models: panelModelNames,
 		judge_model: judgeName,
+		...(profileName ? { panel_profile: profileName } : {}),
+		...(panelReasoningDetails ? { panel_reasoning: panelReasoningDetails } : {}),
+		...(judgeReasoningDetails ? { judge_reasoning: judgeReasoningDetails } : {}),
 		...(toolsEnabled
 			? { panel_tools: { mode: selectionLabel(toolSelection), max_tool_calls: maxToolCalls, serialized: mutating } }
 			: {}),
@@ -243,4 +412,3 @@ function classifyAllPanelFailure(failed: PanelResult[]): FusionDetails["failure_
 	}
 	return "all_panels_failed";
 }
-

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
-import { type AutocompleteItem, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import type { AutocompleteItem } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 import { existsSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
@@ -17,15 +17,16 @@ import {
 	DEFAULT_MAX_TOOL_CALLS,
 	generateConfigExample,
 	loadConfig,
+	resolveEffectiveConfig,
 	type FusionConfig,
 } from "./config.ts";
 import { buildRecentContextFromEntries, type FusionContextMode, normalizeContextTurns } from "./context.ts";
-import { resolveFusionModels, runFusion } from "./fusion.ts";
+import { resolveFusionModels, resolveFusionSelection, runFusion } from "./fusion.ts";
 import { modelDisplay } from "./models.ts";
 import { clampMaxToolCalls, isMutatingSelection, selectionLabel } from "./tools.ts";
-import { selectFusionSetup, type FusionMode, type FusionSetupState } from "./ui.ts";
+import { selectFusionSetup, type FusionMode, type FusionSetupProfile, type FusionSetupState } from "./ui.ts";
 import { formatResult } from "./format.ts";
-import type { FooterDisplay, FusionOptions, ToolMode } from "./types.ts";
+import type { FooterDisplay, FusionOptions, ThinkingLevel, ToolMode } from "./types.ts";
 const FusionParams = Type.Object(
 	{
 		prompt: Type.String({
@@ -58,33 +59,59 @@ const FusionParams = Type.Object(
 	{ description: "Multi-model deliberation parameters" },
 );
 
-function formatTokens(count: number): string {
-	if (count < 1000) return count.toString();
-	if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
-	if (count < 1000000) return `${Math.round(count / 1000)}k`;
-	if (count < 10000000) return `${(count / 1000000).toFixed(1)}M`;
-	return `${Math.round(count / 1000000)}M`;
+export type PanelCommandParseResult =
+	| { ok: true; prompt: string; panelName?: string }
+	| { ok: false; error: string };
+
+/** Consume only a leading `--panel <name>` pair; the remaining prompt is opaque. */
+export function parsePanelCommand(args: string): PanelCommandParseResult {
+	if (!args.startsWith("--panel") || (args.length > 7 && !/\s/.test(args[7]))) {
+		return { ok: true, prompt: args.trim() };
+	}
+	let cursor = 7;
+	while (cursor < args.length && /\s/.test(args[cursor])) cursor++;
+	if (cursor >= args.length) return { ok: false, error: "Missing named panel name after --panel." };
+	const nameStart = cursor;
+	while (cursor < args.length && !/\s/.test(args[cursor])) cursor++;
+	const panelName = args.slice(nameStart, cursor);
+	if (cursor >= args.length) return { ok: false, error: `Missing prompt after named panel "${panelName}".` };
+	const prompt = args.slice(cursor + 1);
+	if (!prompt.trim()) return { ok: false, error: `Missing prompt after named panel "${panelName}".` };
+	return { ok: true, panelName, prompt };
 }
 
-function formatCwd(cwd: string): string {
-	const home = process.env.HOME || process.env.USERPROFILE;
-	if (home && cwd === home) return "~";
-	if (home && cwd.startsWith(`${home}/`)) return `~/${cwd.slice(home.length + 1)}`;
-	return cwd;
+export interface PendingPanelSelection {
+	panelName: string;
+	sessionId: string;
+	agentActive: boolean;
 }
 
-function alignLine(left: string, right: string, width: number): string {
-	const leftWidth = visibleWidth(left);
-	const rightWidth = visibleWidth(right);
-	if (leftWidth + 2 + rightWidth <= width) {
-		return left + " ".repeat(width - leftWidth - rightWidth) + right;
+export function armPendingPanel(panelName: string, sessionId: string): PendingPanelSelection {
+	return { panelName, sessionId, agentActive: false };
+}
+
+export function activatePendingPanel(
+	pending: PendingPanelSelection | undefined,
+	sessionId: string,
+): PendingPanelSelection | undefined {
+	return pending?.sessionId === sessionId ? { ...pending, agentActive: true } : pending;
+}
+
+export function consumePendingPanel(
+	pending: PendingPanelSelection | undefined,
+	sessionId: string,
+): { panelName: string | undefined; pending: PendingPanelSelection | undefined } {
+	if (!pending || pending.sessionId !== sessionId || !pending.agentActive) {
+		return { panelName: undefined, pending };
 	}
-	const availableLeft = Math.max(0, width - rightWidth - 2);
-	if (availableLeft > 0) {
-		const truncatedLeft = truncateToWidth(left, availableLeft, "...");
-		return truncatedLeft + " ".repeat(Math.max(1, width - visibleWidth(truncatedLeft) - rightWidth)) + right;
-	}
-	return truncateToWidth(right, width, "");
+	return { panelName: pending.panelName, pending: undefined };
+}
+
+export function clearPendingPanel(
+	pending: PendingPanelSelection | undefined,
+	sessionId: string,
+): PendingPanelSelection | undefined {
+	return pending?.sessionId === sessionId ? undefined : pending;
 }
 
 function normalizeMode(state: { enabled?: boolean; mode?: FusionMode } | undefined): FusionMode {
@@ -108,35 +135,7 @@ function effectiveFooterDisplay(ctx: ExtensionContext): FooterDisplay {
 }
 
 function footerStatusLine(display: FooterDisplay): string {
-	return `Footer: ${display}`;
-}
-
-function sanitizeFooterStatusText(text: string): string {
-	return text
-		.replace(/\x1B[\]PX^_][^\x07\x1B]*(?:\x07|\x1B\\)/g, "")
-		.replace(/[\x90\x98\x9D\x9E\x9F][^\x07\x9C]*(?:\x07|\x9C)/g, "")
-		.replace(/\x9B[0-?]*[ -/]*[@-~]/g, "")
-		.replace(/\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])/g, "")
-		.replace(/[\r\n\t]/g, " ")
-		.replace(/[\x00-\x08\x0B\x0C\x0E-\x1F\x7F-\x9F]/g, "")
-		.replace(/ +/g, " ")
-		.trim();
-}
-
-export function formatExtensionStatusLine(
-	extensionStatuses: ReadonlyMap<string, string>,
-	width: number,
-	ellipsis = "...",
-): string | undefined {
-	if (extensionStatuses.size === 0) return undefined;
-	const statusLine = Array.from(extensionStatuses.entries())
-		.sort(([a], [b]) => a.localeCompare(b))
-		.map(([, text]) => sanitizeFooterStatusText(text))
-		.filter((text) => text.length > 0)
-		.join(" ");
-	if (!statusLine) return undefined;
-	const truncated = truncateToWidth(statusLine, width, ellipsis);
-	return ellipsis.includes("\x1B") ? truncated : truncated.replace(/\x1B\[0m/g, "");
+	return `Fusion status: ${display}`;
 }
 
 export function fusionFooterText(
@@ -144,13 +143,20 @@ export function fusionFooterText(
 	judgeId: string | undefined,
 	mode: FusionMode = "available",
 	display: FooterDisplay = "full",
+	state?: Pick<FusionSetupState, "profileName" | "panelReasoning" | "judgeReasoning">,
 ): string | undefined {
 	if (display === "off") return undefined;
 	if (selectedIds.size === 0) return mode === "off" ? "Fusion off" : undefined;
 	const panel = Array.from(selectedIds);
 	if (display === "compact") return `${modeLabel(mode)} • ${panel.length} panel`;
 	const judge = judgeId ?? panel[0];
-	return `${modeLabel(mode)} • ${panel.length} panel • judge ${judge}`;
+	const parts = [modeLabel(mode)];
+	if (state?.profileName) parts.push(`named panel ${state.profileName}`);
+	parts.push(`${panel.length} panel`);
+	if (state?.panelReasoning) parts.push(`panel reasoning ${state.panelReasoning}`);
+	if (state?.judgeReasoning) parts.push(`judge reasoning ${state.judgeReasoning}`);
+	parts.push(`judge ${judge}`);
+	return parts.join(" • ");
 }
 
 /** Footer/status suffix describing panel tool access, when enabled. */
@@ -169,94 +175,16 @@ function toolsStatusLine(state: FusionSetupState | undefined): string {
 }
 
 function updateStatus(
-	pi: ExtensionAPI,
 	ctx: ExtensionContext,
 	selectedIds: Set<string>,
 	judgeId: string | undefined,
 	mode: FusionMode = "available",
 ) {
-	ctx.ui.setStatus("fusion", undefined);
-	ctx.ui.setWidget("fusion-panel", undefined);
-
 	const footerDisplay = effectiveFooterDisplay(ctx);
-	const baseText = fusionFooterText(selectedIds, judgeId, mode, footerDisplay);
-	const fusionText = baseText && footerDisplay === "full" ? baseText + toolsSuffix(effectiveDisplayState(ctx)) : baseText;
-	if (!fusionText) {
-		// Restore Pi's built-in footer when pi-fusion has nothing to add.
-		ctx.ui.setFooter(undefined);
-		return;
-	}
-
-	ctx.ui.setFooter((tui, theme, footerData) => {
-		const unsub = footerData.onBranchChange(() => tui.requestRender());
-		return {
-			dispose: unsub,
-			invalidate() {},
-			render(width: number): string[] {
-				let input = 0;
-				let output = 0;
-				let cacheRead = 0;
-				let cacheWrite = 0;
-				let cost = 0;
-				let latestCacheHitRate: number | undefined;
-
-				for (const entry of ctx.sessionManager.getEntries()) {
-					if (entry.type === "message" && entry.message.role === "assistant") {
-						const usage = entry.message.usage;
-						input += usage.input;
-						output += usage.output;
-						cacheRead += usage.cacheRead;
-						cacheWrite += usage.cacheWrite;
-						cost += usage.cost.total;
-						const latestPromptTokens = usage.input + usage.cacheRead + usage.cacheWrite;
-						latestCacheHitRate = latestPromptTokens > 0 ? (usage.cacheRead / latestPromptTokens) * 100 : undefined;
-					}
-				}
-
-				const contextUsage = ctx.getContextUsage();
-				const contextWindow = contextUsage?.contextWindow ?? ctx.model?.contextWindow ?? 0;
-				const contextPercent = contextUsage?.percent === null ? "?" : (contextUsage?.percent ?? 0).toFixed(1);
-				const stats: string[] = [];
-				if (input) stats.push(`↑${formatTokens(input)}`);
-				if (output) stats.push(`↓${formatTokens(output)}`);
-				if (cacheRead) stats.push(`R${formatTokens(cacheRead)}`);
-				if (cacheWrite) stats.push(`W${formatTokens(cacheWrite)}`);
-				if ((cacheRead > 0 || cacheWrite > 0) && latestCacheHitRate !== undefined) {
-					stats.push(`CH${latestCacheHitRate.toFixed(1)}%`);
-				}
-				const usingSubscription = ctx.model ? ctx.modelRegistry.isUsingOAuth(ctx.model) : false;
-				if (cost || usingSubscription) stats.push(`$${cost.toFixed(3)}${usingSubscription ? " (sub)" : ""}`);
-				stats.push(`${contextPercent}%/${formatTokens(contextWindow)} (auto)`);
-
-				let cwd = formatCwd(ctx.cwd);
-				const branch = footerData.getGitBranch();
-				if (branch) cwd += ` (${branch})`;
-				const sessionName = ctx.sessionManager.getSessionName();
-				if (sessionName) cwd += ` • ${sessionName}`;
-
-				let model = ctx.model?.id ?? "no-model";
-				if (ctx.model?.reasoning) {
-					const thinking = pi.getThinkingLevel();
-					model = thinking === "off" ? `${model} • thinking off` : `${model} • ${thinking}`;
-				}
-				if (ctx.model && footerData.getAvailableProviderCount() > 1) {
-					const withProvider = `(${ctx.model.provider}) ${model}`;
-					if (visibleWidth(withProvider) < width) model = withProvider;
-				}
-
-				const top = alignLine(theme.fg("dim", cwd), fusionText ? theme.fg("dim", fusionText) : "", width);
-				const bottom = alignLine(theme.fg("dim", stats.join(" ")), theme.fg("dim", model), width);
-				const lines = [top, bottom];
-				const extensionStatusLine = formatExtensionStatusLine(
-					footerData.getExtensionStatuses(),
-					width,
-					theme.fg("dim", "..."),
-				);
-				if (extensionStatusLine) lines.push(extensionStatusLine);
-				return lines;
-			},
-		};
-	});
+	const state = effectiveDisplayState(ctx);
+	const baseText = fusionFooterText(selectedIds, judgeId, mode, footerDisplay, state);
+	const fusionText = baseText && footerDisplay === "full" ? baseText + toolsSuffix(state) : baseText;
+	ctx.ui.setStatus("fusion", fusionText);
 }
 
 function persistSessionState(
@@ -264,17 +192,19 @@ function persistSessionState(
 	selectedIds: Set<string>,
 	judgeId: string | undefined,
 	mode: FusionMode = "available",
-	tools: Pick<FusionSetupState, "panelTools" | "maxToolCalls" | "toolsConsented" | "footerDisplay"> = {},
+	settings: Pick<FusionSetupState, "panelTools" | "maxToolCalls" | "toolsConsented" | "footerDisplay" | "panelReasoning" | "judgeReasoning"> = {},
 ) {
 	pi.appendEntry("fusion-state", {
 		selectedIds: Array.from(selectedIds),
 		judgeId,
 		enabled: mode === "forced",
 		mode,
-		panelTools: tools.panelTools,
-		maxToolCalls: tools.maxToolCalls,
-		toolsConsented: tools.toolsConsented,
-		footerDisplay: tools.footerDisplay,
+		panelTools: settings.panelTools,
+		maxToolCalls: settings.maxToolCalls,
+		toolsConsented: settings.toolsConsented,
+		footerDisplay: settings.footerDisplay,
+		panelReasoning: settings.panelReasoning,
+		judgeReasoning: settings.judgeReasoning,
 		timestamp: Date.now(),
 	});
 }
@@ -293,6 +223,8 @@ function restoreSessionState(ctx: ExtensionContext): FusionSetupState | undefine
 				maxToolCalls?: number;
 				toolsConsented?: boolean;
 				footerDisplay?: FooterDisplay;
+				panelReasoning?: ThinkingLevel;
+				judgeReasoning?: ThinkingLevel;
 			};
 			const mode = normalizeMode(data);
 			return {
@@ -303,7 +235,11 @@ function restoreSessionState(ctx: ExtensionContext): FusionSetupState | undefine
 				panelTools: data.panelTools,
 				maxToolCalls: data.maxToolCalls,
 				toolsConsented: data.toolsConsented,
-				footerDisplay: normalizeFooterDisplay(data.footerDisplay),
+				footerDisplay: data.footerDisplay === undefined
+					? undefined
+					: normalizeFooterDisplay(data.footerDisplay),
+				panelReasoning: data.panelReasoning,
+				judgeReasoning: data.judgeReasoning,
 			};
 		}
 	}
@@ -319,14 +255,18 @@ function effectiveDisplayState(ctx: ExtensionContext): FusionSetupState | undefi
 	const session = restoreSessionState(ctx);
 	if (session?.selectedIds.size || normalizeMode(session) === "off") return session;
 	const cfg = loadConfig(ctx.cwd, ctx.isProjectTrusted());
-	if ((cfg.panel && cfg.panel.length > 0) || cfg.judge) {
+	const effective = resolveEffectiveConfig(cfg);
+	if (effective.ok && ((effective.config.panel && effective.config.panel.length > 0) || effective.config.judge)) {
 		return {
-			selectedIds: new Set(cfg.panel ?? []),
-			judgeId: cfg.judge,
+			selectedIds: new Set(effective.config.panel ?? []),
+			judgeId: effective.config.judge,
+			profileName: effective.profileName,
+			panelReasoning: effective.config.panelReasoning,
+			judgeReasoning: effective.config.judgeReasoning,
 			mode: "available",
-			panelTools: typeof cfg.panelTools === "string" ? cfg.panelTools : undefined,
-			maxToolCalls: cfg.maxToolCalls,
-			footerDisplay: normalizeFooterDisplay(cfg.footerDisplay),
+			panelTools: typeof effective.config.panelTools === "string" ? effective.config.panelTools : undefined,
+			maxToolCalls: effective.config.maxToolCalls,
+			footerDisplay: normalizeFooterDisplay(effective.config.footerDisplay),
 		};
 	}
 	return session;
@@ -340,6 +280,8 @@ function sessionFusionOptions(ctx: ExtensionContext): FusionOptions {
 		panel_tools:
 			sessionState?.panelTools && sessionState.panelTools !== "none" ? sessionState.panelTools : undefined,
 		max_tool_calls: sessionState?.maxToolCalls,
+		panel_reasoning: sessionState?.panelReasoning,
+		judge_reasoning: sessionState?.judgeReasoning,
 	};
 	if (!sessionState?.selectedIds.size) return tools;
 	return {
@@ -371,12 +313,22 @@ export function buildInitialState(
 	resolvedJudge: ModelWithDisplay,
 	configPanelTools?: FusionConfig["panelTools"],
 	configFooterDisplay?: FusionConfig["footerDisplay"],
+	setup: {
+		profiles?: Record<string, FusionSetupProfile>;
+		profileName?: string;
+		panelReasoning?: ThinkingLevel;
+		judgeReasoning?: ThinkingLevel;
+	} = {},
 ): FusionSetupState {
 	const sessionState = restoreSessionState(ctx);
 	const configTools = typeof configPanelTools === "string" ? configPanelTools : undefined;
 	return {
 		selectedIds: sessionState?.selectedIds ?? new Set(resolvedPanel.map((m) => m.display)),
 		judgeId: sessionState?.judgeId ?? resolvedJudge.display,
+		profileName: sessionState ? undefined : setup.profileName,
+		profiles: setup.profiles,
+		panelReasoning: sessionState?.panelReasoning ?? setup.panelReasoning,
+		judgeReasoning: sessionState?.judgeReasoning ?? setup.judgeReasoning,
 		enabled: normalizeMode(sessionState) === "forced",
 		mode: normalizeMode(sessionState),
 		panelTools: sessionState?.panelTools && sessionState.panelTools !== "none"
@@ -420,19 +372,23 @@ async function applySetup(
 
 	const mode = normalizeMode(state);
 	persistSessionState(pi, state.selectedIds, state.judgeId, mode, state);
-	updateStatus(pi, ctx, state.selectedIds, state.judgeId, mode);
+	updateStatus(ctx, state.selectedIds, state.judgeId, mode);
 	const panelNames = Array.from(state.selectedIds).join(", ");
+	const profileNote = state.profileName ? `\nNamed panel: ${state.profileName}` : "";
+	const reasoningNote = `\nPanel reasoning: ${state.panelReasoning ?? "off"}\nJudge reasoning: ${state.judgeReasoning ?? "off"}`;
 	const toolsNote = state.panelTools && state.panelTools !== "none"
 		? `\nTools: ${selectionLabel(state.panelTools)} (max ${clampMaxToolCalls(state.maxToolCalls)})`
 		: "";
 	ctx.ui.notify(
-		`Panel: ${panelNames}\nJudge: ${state.judgeId}${toolsNote}${warnings.length ? "\nWarnings: " + warnings.join("; ") : ""}`,
+		`Panel: ${panelNames}\nJudge: ${state.judgeId}${profileNote}${reasoningNote}${toolsNote}${warnings.length ? "\nWarnings: " + warnings.join("; ") : ""}`,
 		"info",
 	);
 	return true;
 }
 
 export default function (pi: ExtensionAPI) {
+	let pendingPanel: PendingPanelSelection | undefined;
+
 	pi.registerTool({
 		name: "fusion",
 		label: "Fusion",
@@ -448,10 +404,12 @@ export default function (pi: ExtensionAPI) {
 			"Do not use the fusion tool for simple tactical prompts, straightforward edits, routine file operations, or questions a single model can answer well.",
 			"Panel and judge calls do not automatically see the full conversation thread. If prior context matters, either include the relevant details in the prompt argument or set context_mode to 'recent' with an appropriate context_turns value.",
 			"Use context_mode='recent' only when needed; keep context_turns small and focused because each panel model receives that context.",
-			"The fusion tool accepts a prompt and optional model overrides; it does not need file paths unless the prompt itself references them.",
+			"The fusion tool accepts only prompt and conversation-context controls; panel, judge, reasoning, tools, and budgets remain user-owned configuration.",
 		],
 		parameters: FusionParams,
 		async execute(_toolCallId, params, signal, onUpdate, ctx) {
+			const consumed = consumePendingPanel(pendingPanel, ctx.sessionManager.getSessionId());
+			pendingPanel = consumed.pending;
 			const sessionState = restoreSessionState(ctx);
 			if (normalizeMode(sessionState) === "off") {
 				return {
@@ -469,10 +427,13 @@ export default function (pi: ExtensionAPI) {
 			// The invoking model cannot set or override any of it; it controls only the prompt
 			// and the conversation-context options above.
 			const options: FusionOptions = {
+				panel_profile: consumed.panelName,
 				analysis_models: sessionOptions.analysis_models,
 				model: sessionOptions.model,
 				panel_tools: sessionOptions.panel_tools,
 				max_tool_calls: sessionOptions.max_tool_calls,
+				panel_reasoning: sessionOptions.panel_reasoning,
+				judge_reasoning: sessionOptions.judge_reasoning,
 				context_text: contextText,
 			};
 			return runFusion(
@@ -490,6 +451,16 @@ export default function (pi: ExtensionAPI) {
 		},
 	});
 
+	async function validateNamedPanel(name: string, ctx: ExtensionContext): Promise<string | undefined> {
+		const selection = await resolveFusionSelection(
+			loadConfig(ctx.cwd, ctx.isProjectTrusted()),
+			ctx.modelRegistry,
+			ctx.model,
+			{ panel_profile: name },
+		);
+		return selection.ok ? undefined : selection.result.details.error ?? `Named panel "${name}" is unavailable.`;
+	}
+
 	pi.registerCommand("fusion", {
 		description: "Set fusion mode: /fusion on | available | off (no arg toggles available/forced; /fusion <prompt> forces once)",
 		getArgumentCompletions: (prefix: string): AutocompleteItem[] | null => {
@@ -502,7 +473,13 @@ export default function (pi: ExtensionAPI) {
 			return filtered.length > 0 ? filtered : null;
 		},
 		handler: async (args, ctx) => {
-			const prompt = args.trim();
+			const parsed = parsePanelCommand(args);
+			if (!parsed.ok) {
+				if (ctx.mode === "print") console.log(parsed.error);
+				else ctx.ui.notify(parsed.error, "warning");
+				return;
+			}
+			const prompt = parsed.prompt;
 			const sessionState = restoreSessionState(ctx);
 			const lower = prompt.toLowerCase();
 			const modeCommand: FusionMode | undefined =
@@ -515,6 +492,7 @@ export default function (pi: ExtensionAPI) {
 							: undefined;
 
 			if (!prompt || modeCommand) {
+				pendingPanel = undefined;
 				if (!sessionState?.selectedIds.size && (modeCommand === "forced" || (!prompt && !modeCommand))) {
 					const message = "No fusion setup yet. Run /fusion-setup first, or use /fusion off to disable.";
 					if (ctx.mode === "print") console.log(message);
@@ -527,7 +505,7 @@ export default function (pi: ExtensionAPI) {
 				const currentMode = normalizeMode(sessionState);
 				const nextMode = modeCommand ?? (currentMode === "forced" ? "available" : "forced");
 				persistSessionState(pi, selectedIds, judgeId, nextMode, sessionState ?? {});
-				updateStatus(pi, ctx, selectedIds, judgeId, nextMode);
+				updateStatus(ctx, selectedIds, judgeId, nextMode);
 				const footerDisplay = effectiveFooterDisplay(ctx);
 				const summaryBase = fusionFooterText(selectedIds, judgeId, nextMode, footerDisplay) ?? modeLabel(nextMode);
 				const summary = footerDisplay === "full" ? summaryBase + toolsSuffix(sessionState) : summaryBase;
@@ -543,8 +521,24 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 
+			if (parsed.panelName) {
+				if (ctx.mode === "print") {
+					console.log("/fusion --panel requires interactive mode. Use /fusion-report --panel <name> <prompt> in print mode.");
+					return;
+				}
+				const error = await validateNamedPanel(parsed.panelName, ctx);
+				if (error) {
+					ctx.ui.notify(error, "error");
+					return;
+				}
+				pendingPanel = armPendingPanel(parsed.panelName, ctx.sessionManager.getSessionId());
+				ctx.ui.notify(`Named panel "${parsed.panelName}" armed for this Fusion run.`, "info");
+			} else {
+				pendingPanel = undefined;
+			}
+
 			if (sessionState?.selectedIds.size) {
-				updateStatus(pi, ctx, sessionState.selectedIds, sessionState.judgeId, normalizeMode(sessionState));
+				updateStatus(ctx, sessionState.selectedIds, sessionState.judgeId, normalizeMode(sessionState));
 			}
 
 			if (ctx.mode === "print") {
@@ -559,17 +553,24 @@ export default function (pi: ExtensionAPI) {
 	pi.registerCommand("fusion-report", {
 		description: "Run fusion directly and write the raw panel/judge diagnostic report into the editor",
 		handler: async (args, ctx) => {
-			const prompt = args.trim();
+			const parsed = parsePanelCommand(args);
+			if (!parsed.ok) {
+				if (ctx.mode === "print") console.log(parsed.error);
+				else ctx.ui.notify(parsed.error, "warning");
+				return;
+			}
+			const prompt = parsed.prompt;
 			if (!prompt) {
-				const usage = "Usage: /fusion-report <prompt>";
+				const usage = "Usage: /fusion-report [--panel <name>] <prompt>";
 				if (ctx.mode === "print") console.log(usage);
 				else ctx.ui.notify(usage, "warning");
 				return;
 			}
 
 			const sessionState = restoreSessionState(ctx);
-			if (sessionState?.selectedIds.size) updateStatus(pi, ctx, sessionState.selectedIds, sessionState.judgeId, normalizeMode(sessionState));
+			if (sessionState?.selectedIds.size) updateStatus(ctx, sessionState.selectedIds, sessionState.judgeId, normalizeMode(sessionState));
 			const overrides = sessionFusionOptions(ctx);
+			if (parsed.panelName) overrides.panel_profile = parsed.panelName;
 
 			ctx.ui.setWorkingMessage("Running fusion report...");
 			try {
@@ -584,6 +585,12 @@ export default function (pi: ExtensionAPI) {
 					sessionState?.toolsConsented ?? false,
 					ctx.signal,
 				);
+				if (result.details.status === "error") {
+					const error = result.details.error ?? "Fusion report failed.";
+					if (ctx.mode === "print") console.log(error);
+					else ctx.ui.notify(error, "error");
+					return;
+				}
 				const failed = (result.details.failed_models ?? []).map((f) => ({
 					model: f.model,
 					provider: f.model.split("/")[0] ?? "",
@@ -627,14 +634,38 @@ export default function (pi: ExtensionAPI) {
 				return;
 			}
 			const config = loadConfig(ctx.cwd, ctx.isProjectTrusted());
-
-			const { panel, judge, warnings } = await resolveFusionModels(
-				ctx.cwd,
+			const selection = await resolveFusionSelection(
+				config,
 				ctx.modelRegistry,
 				ctx.model,
-				ctx.isProjectTrusted(),
 				{},
 			);
+			if (!selection.ok) {
+				ctx.ui.notify(selection.result.details.error ?? "Fusion setup could not resolve models.", "error");
+				return;
+			}
+			const { panel, judge, warnings } = selection.resolution;
+			const profiles: Record<string, FusionSetupProfile> = {};
+			const profileNames = Object.keys(config.panels ?? {}).sort();
+			const resolvedProfiles = await Promise.all(
+				profileNames.map((name) => resolveFusionSelection(
+					config,
+					ctx.modelRegistry,
+					ctx.model,
+					{ panel_profile: name },
+				)),
+			);
+			for (let i = 0; i < profileNames.length; i++) {
+				const name = profileNames[i];
+				const profile = resolvedProfiles[i];
+				if (!profile.ok) continue;
+				profiles[name] = {
+					selectedIds: profile.resolution.panel.map(modelDisplay),
+					judgeId: modelDisplay(profile.resolution.judge),
+					panelReasoning: profile.config.panelReasoning,
+					judgeReasoning: profile.config.judgeReasoning,
+				};
+			}
 
 			const initial: FusionSetupState = buildInitialState(
 				ctx,
@@ -642,6 +673,12 @@ export default function (pi: ExtensionAPI) {
 				{ display: modelDisplay(judge) },
 				config.panelTools,
 				config.footerDisplay,
+				{
+					profiles,
+					profileName: selection.resolution.profileName,
+					panelReasoning: selection.config.panelReasoning,
+					judgeReasoning: selection.config.judgeReasoning,
+				},
 			);
 
 			const state = await selectFusionSetup(ctx, available, initial);
@@ -719,14 +756,17 @@ export default function (pi: ExtensionAPI) {
 			} else {
 				const mode = normalizeMode(state);
 				lines.push(`Mode: ${mode}`);
+				if (state.profileName) lines.push(`Named panel: ${state.profileName}`);
 				lines.push(`Panel: ${Array.from(state.selectedIds).join(", ")}${fromConfig ? "  (from fusion.json)" : ""}`);
 				lines.push(`Judge: ${state.judgeId ?? Array.from(state.selectedIds)[0]}`);
+				lines.push(`Panel reasoning: ${state.panelReasoning ?? "off"}`);
+				lines.push(`Judge reasoning: ${state.judgeReasoning ?? "off"}`);
 				lines.push(toolsStatusLine(state));
 				lines.push(footerStatusLine(footerDisplay));
 				lines.push("");
 				lines.push("Use /fusion to toggle available/forced, /fusion off to disable, /fusion <prompt> to force once. Change panel tools with /fusion-setup.");
-				updateStatus(pi, ctx, state.selectedIds, state.judgeId, mode);
 			}
+			updateStatus(ctx, state?.selectedIds ?? new Set(), state?.judgeId, normalizeMode(state));
 			const text = lines.join("\n");
 			if (ctx.mode === "print") console.log(text);
 			else ctx.ui.notify(text, "info");
@@ -747,19 +787,37 @@ export default function (pi: ExtensionAPI) {
 		if (isFusionPrompt(event.text.trim())) return { action: "continue" };
 		const state = restoreSessionState(ctx);
 		if (normalizeMode(state) !== "forced" || !state?.selectedIds.size) return { action: "continue" };
-		updateStatus(pi, ctx, state.selectedIds, state.judgeId, "forced");
+		updateStatus(ctx, state.selectedIds, state.judgeId, "forced");
 		return { action: "transform", text: forceFusionPrompt(event.text), images: event.images };
 	});
 
-	// Refresh the footer whenever the session/model changes (pi.on is overloaded per
+	pi.on("agent_start", async (_event, ctx) => {
+		pendingPanel = activatePendingPanel(pendingPanel, ctx.sessionManager.getSessionId());
+	});
+	pi.on("agent_end", async (_event, ctx) => {
+		const sessionId = ctx.sessionManager.getSessionId();
+		if (pendingPanel?.sessionId === sessionId && pendingPanel.agentActive && ctx.mode !== "print") {
+			ctx.ui.notify(`Named panel "${pendingPanel.panelName}" was not used because the agent did not call Fusion.`, "warning");
+		}
+		pendingPanel = clearPendingPanel(pendingPanel, sessionId);
+	});
+	pi.on("session_shutdown", async () => {
+		pendingPanel = undefined;
+	});
+
+	// Refresh Fusion's keyed status whenever the session/model changes (pi.on is overloaded per
 	// event name, so register the shared handler for each rather than looping).
 	const refreshFooter = (ctx: ExtensionContext) => {
 		const state = effectiveDisplayState(ctx);
-		if (state && (state.selectedIds.size || normalizeMode(state) === "off")) {
-			updateStatus(pi, ctx, state.selectedIds, state.judgeId, normalizeMode(state));
-		}
+		updateStatus(ctx, state?.selectedIds ?? new Set(), state?.judgeId, normalizeMode(state));
 	};
-	pi.on("session_start", async (_event, ctx) => refreshFooter(ctx));
-	pi.on("session_tree", async (_event, ctx) => refreshFooter(ctx));
+	pi.on("session_start", async (_event, ctx) => {
+		pendingPanel = undefined;
+		refreshFooter(ctx);
+	});
+	pi.on("session_tree", async (_event, ctx) => {
+		pendingPanel = undefined;
+		refreshFooter(ctx);
+	});
 	pi.on("model_select", async (_event, ctx) => refreshFooter(ctx));
 }

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -4,6 +4,7 @@
 
 import {
 	complete,
+	getSupportedThinkingLevels,
 	type Api,
 	type AssistantMessage,
 	type Message,
@@ -11,6 +12,7 @@ import {
 	type Tool,
 	type ToolCall,
 	type ToolResultMessage,
+	type ThinkingLevel,
 } from "@earendil-works/pi-ai";
 import type { ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { TOOL_OUTPUT_MAX_BYTES } from "./config.ts";
@@ -26,14 +28,37 @@ type CompleteOptions = {
 	signal?: AbortSignal;
 	maxTokens: number;
 	temperature?: number;
+	reasoning?: ThinkingLevel;
 };
 
-async function buildCompleteOptions(
+export interface ModelReasoningResolution {
+	requested?: ThinkingLevel;
+	effective?: ThinkingLevel;
+	warning?: string;
+}
+
+/** Resolve without clamping so configured cost/effort changes are never silent. */
+export function resolveModelReasoning(
+	model: Model<Api>,
+	requested: ThinkingLevel | undefined,
+): ModelReasoningResolution {
+	if (!requested) return {};
+	if (getSupportedThinkingLevels(model).includes(requested)) {
+		return { requested, effective: requested };
+	}
+	return {
+		requested,
+		warning: `Reasoning ${requested} is not supported by ${modelDisplay(model)}; running that model without requested reasoning.`,
+	};
+}
+
+export async function buildCompleteOptions(
 	registry: ModelRegistry,
 	model: Model<Api>,
 	maxTokens: number,
 	temperature: number,
 	signal: AbortSignal | undefined,
+	reasoning?: ThinkingLevel,
 ): Promise<CompleteOptions> {
 	const auth = await registry.getApiKeyAndHeaders(model);
 	if (!auth.ok || !auth.apiKey) {
@@ -49,6 +74,7 @@ async function buildCompleteOptions(
 	if (getSupportsTemperature(model)) {
 		options.temperature = temperature;
 	}
+	if (reasoning) options.reasoning = reasoning;
 	return options;
 }
 
@@ -60,8 +86,9 @@ export async function callModelText(
 	maxTokens: number,
 	temperature: number,
 	signal: AbortSignal | undefined,
+	reasoning?: ThinkingLevel,
 ): Promise<AssistantMessage> {
-	const options = await buildCompleteOptions(registry, model, maxTokens, temperature, signal);
+	const options = await buildCompleteOptions(registry, model, maxTokens, temperature, signal, reasoning);
 	return runComplete(
 		model,
 		{ systemPrompt, messages: [{ role: "user", content: userText, timestamp: Date.now() }] },
@@ -100,8 +127,9 @@ export async function callModelWithTools(
 	maxToolCalls: number,
 	ctx: ExtensionContext,
 	onToolEvent?: (ev: { name: string; turn: number; ok: boolean }) => void,
+	reasoning?: ThinkingLevel,
 ): Promise<ToolLoopResult> {
-	const options = await buildCompleteOptions(registry, model, maxTokens, temperature, signal);
+	const options = await buildCompleteOptions(registry, model, maxTokens, temperature, signal, reasoning);
 	const tools: Tool[] = toolDefs.map((d) => ({ name: d.name, description: d.description, parameters: d.parameters }));
 	const byName = new Map(toolDefs.map((d) => [d.name, d]));
 

--- a/src/models.ts
+++ b/src/models.ts
@@ -54,6 +54,14 @@ export function selectDiversePanel(available: Model<Api>[], max: number): Model<
 }
 
 export interface ResolveOptions {
+	/** Ordered user/config candidates. When present, replaces the legacy session/config fields below. */
+	candidates?: ResolveCandidate[];
+	/** Judge used only when resolution reaches auto/current fallback. */
+	autoJudge?: string;
+	/** Max size for auto-diverse selection when candidates are supplied. */
+	autoMaxPanelModels?: number;
+	/** Warnings produced by config normalization before model resolution. */
+	warnings?: string[];
 	sessionPanel?: string[];
 	sessionJudge?: string;
 	configPanel?: string[];
@@ -62,10 +70,35 @@ export interface ResolveOptions {
 	currentModel?: Model<Api>;
 }
 
+export type ResolveSource = "session" | "explicit" | "default" | "legacy" | "auto" | "current";
+
+export interface ResolveCandidate {
+	source: Exclude<ResolveSource, "auto" | "current">;
+	panel: string[];
+	judge?: string;
+	maxPanelModels: number;
+	profileName?: string;
+	/** Fail closed when no candidate model is authenticated. */
+	strict?: boolean;
+}
+
 export interface ResolveResult {
 	panel: Model<Api>[];
 	judge: Model<Api>;
 	warnings: string[];
+	source: ResolveSource;
+	profileName?: string;
+}
+
+export class PanelSelectionError extends Error {
+	constructor(
+		public readonly profileName: string | undefined,
+		public readonly warnings: string[],
+		message: string,
+	) {
+		super(message);
+		this.name = "PanelSelectionError";
+	}
 }
 
 function resolvePanelIdentifiers(
@@ -97,50 +130,65 @@ export async function resolvePanelAndJudge(
 	registry: ModelRegistry,
 	options: ResolveOptions,
 ): Promise<ResolveResult> {
-	const warnings: string[] = [];
+	const warnings: string[] = [...(options.warnings ?? [])];
 	const configuredMaxPanel = Math.min(
-		options.configMaxPanelModels ?? DEFAULT_MAX_PANEL_MODELS,
+		options.autoMaxPanelModels ?? options.configMaxPanelModels ?? DEFAULT_MAX_PANEL_MODELS,
 		MAX_PANEL_MODELS_HARD_LIMIT,
 	);
-	const sessionMaxPanel = MAX_PANEL_MODELS_HARD_LIMIT;
+	const candidates = options.candidates ?? legacyResolveCandidates(options, configuredMaxPanel);
 
 	let panel: Model<Api>[] = [];
+	let selected: ResolveCandidate | undefined;
+	for (const candidate of candidates) {
+		if (candidate.panel.length === 0) continue;
+		const maxPanel = Math.min(candidate.maxPanelModels, MAX_PANEL_MODELS_HARD_LIMIT);
+		panel = resolvePanelIdentifiers(registry, candidate.panel, maxPanel, warnings);
+		if (panel.length > 0) {
+			selected = candidate;
+			break;
+		}
 
-	// 1. Session selection has highest priority.
-	if (options.sessionPanel && options.sessionPanel.length > 0) {
-		panel = resolvePanelIdentifiers(registry, options.sessionPanel, sessionMaxPanel, warnings);
-		if (panel.length === 0) {
-			warnings.push("Session panel contained no authed models; falling back to config/auto-selection.");
+		const label = candidate.profileName
+			? `Named panel "${candidate.profileName}"`
+			: candidate.source === "session"
+				? "Session panel"
+				: "Legacy panel";
+		const message = `${label} contained no authed models.`;
+		warnings.push(candidate.strict ? message : `${message} Trying the next configured candidate.`);
+		if (candidate.strict) {
+			throw new PanelSelectionError(candidate.profileName, warnings, message);
 		}
 	}
 
-	// 2. File config panel.
-	if (panel.length === 0 && options.configPanel && options.configPanel.length > 0) {
-		panel = resolvePanelIdentifiers(registry, options.configPanel, configuredMaxPanel, warnings);
-		if (panel.length === 0) {
-			warnings.push("Explicit panel contained no authed models; falling back to auto-selection.");
-		}
+	let source: ResolveSource;
+	if (selected) {
+		source = selected.source;
+	} else {
+		panel = selectDiversePanel(registry.getAvailable(), configuredMaxPanel);
+		source = "auto";
 	}
 
-	// 3. Auto-diverse selection.
-	if (panel.length === 0) {
-		const available = registry.getAvailable();
-		panel = selectDiversePanel(available, configuredMaxPanel);
-	}
-
-	// 4. Final fallback to current model.
+	// Final fallback to current model.
 	if (panel.length === 0 && options.currentModel && registry.hasConfiguredAuth(options.currentModel)) {
 		panel = [options.currentModel];
+		source = "current";
 	}
 
 	if (panel.length === 0) {
 		throw new Error("No authed models available for the fusion panel. Configure models in ~/.pi/agent/fusion.json or authenticate more providers.");
 	}
 
-	// Resolve judge: session > config > current model > first panel model.
+	// The judge belongs to the candidate that actually supplied the panel. A judge
+	// from a failed named candidate must never leak into legacy/auto fallback.
 	let judge: Model<Api> | undefined;
-
-	for (const candidateId of [options.sessionJudge, options.configJudge]) {
+	const selectedJudge = selected?.judge ?? (
+		selected?.source === "session"
+			? options.autoJudge ?? options.configJudge
+			: selected
+				? undefined
+				: options.autoJudge ?? options.configJudge
+	);
+	for (const candidateId of [selectedJudge]) {
 		if (judge || !candidateId) continue;
 		const resolved = resolveModelIdentifier(registry, candidateId);
 		if (!resolved) {
@@ -160,6 +208,33 @@ export async function resolvePanelAndJudge(
 		judge = panel[0];
 	}
 
-	return { panel, judge, warnings };
+	return {
+		panel,
+		judge,
+		warnings,
+		source,
+		...(selected?.profileName ? { profileName: selected.profileName } : {}),
+	};
 }
 
+/** Preserve the public resolver's original session -> config -> auto behavior. */
+function legacyResolveCandidates(options: ResolveOptions, configuredMaxPanel: number): ResolveCandidate[] {
+	const candidates: ResolveCandidate[] = [];
+	if (options.sessionPanel?.length) {
+		candidates.push({
+			source: "session",
+			panel: options.sessionPanel,
+			judge: options.sessionJudge,
+			maxPanelModels: MAX_PANEL_MODELS_HARD_LIMIT,
+		});
+	}
+	if (options.configPanel?.length) {
+		candidates.push({
+			source: "legacy",
+			panel: options.configPanel,
+			judge: options.configJudge,
+			maxPanelModels: configuredMaxPanel,
+		});
+	}
+	return candidates;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,20 +2,36 @@
  * Shared types for pi-fusion.
  */
 
-import type { Api, Model } from "@earendil-works/pi-ai";
+import type { Api, Model, ThinkingLevel } from "@earendil-works/pi-ai";
 
-export type { Api, Model };
+export type { Api, Model, ThinkingLevel };
 
 /** Named panel tool bundles, or an explicit list of tool names. */
 export type ToolMode = "none" | "readonly" | "all";
 export type ToolSelection = ToolMode | string[];
 export type FooterDisplay = "off" | "compact" | "full";
 
+/** A reusable user-owned panel configuration. Global runtime knobs remain shared. */
+export interface NamedPanelConfig {
+	models: string[];
+	judge?: string;
+	panelReasoning?: ThinkingLevel;
+	judgeReasoning?: ThinkingLevel;
+}
+
 export interface FusionConfig {
 	/** Explicit panel model identifiers, e.g. ["anthropic/claude-sonnet-4-5"]. */
 	panel?: string[];
 	/** Explicit judge model identifier. */
 	judge?: string;
+	/** Named reusable panel configurations. */
+	panels?: Record<string, NamedPanelConfig>;
+	/** Named panel used when no explicit/session selection is active. */
+	defaultPanel?: string;
+	/** Reasoning effort applied to panel model calls. */
+	panelReasoning?: ThinkingLevel;
+	/** Reasoning effort applied to judge model calls. */
+	judgeReasoning?: ThinkingLevel;
 	/** Max panel models (1–8). */
 	maxPanelModels?: number;
 	/** Max tokens per panel response. */
@@ -30,7 +46,7 @@ export interface FusionConfig {
 	maxToolCalls?: number;
 	/** Non-interactive consent for mutating tools (bash/edit/write) — required in print/no-UI mode. */
 	panelToolsConsent?: boolean;
-	/** Footer verbosity: "full" (default), "compact", or "off". */
+	/** Fusion status verbosity: "full" (default), "compact", or "off". */
 	footerDisplay?: FooterDisplay;
 }
 
@@ -42,6 +58,29 @@ export type ResolvedFusionConfig = FusionConfig & {
 	temperature: number;
 	maxToolCalls: number;
 };
+
+export type ConfigSelectionSource = "explicit" | "default" | "legacy";
+export type ConfigSelectionErrorCode = "unknown_named_panel" | "invalid_named_panel";
+
+export interface ConfigSelectionError {
+	code: ConfigSelectionErrorCode;
+	panelName: string;
+	message: string;
+}
+
+export type EffectiveConfigResult =
+	| {
+		ok: true;
+		config: ResolvedFusionConfig;
+		profileName?: string;
+		source: ConfigSelectionSource;
+		warnings: string[];
+	}
+	| {
+		ok: false;
+		error: ConfigSelectionError;
+		warnings: string[];
+	};
 
 export interface PanelResult {
 	model: string;
@@ -61,6 +100,8 @@ export interface FusionAnalysis {
 }
 
 export interface FusionOptions {
+	/** Internal user-selected named panel. Never exposed on the registered tool schema. */
+	panel_profile?: string;
 	analysis_models?: string[];
 	/** OpenRouter-compatible judge parameter name. */
 	model?: string;
@@ -72,6 +113,9 @@ export interface FusionOptions {
 	panel_tools?: ToolMode;
 	/** Per-call max tool-call steps per panel model (1–100). */
 	max_tool_calls?: number;
+	/** Internal session/config reasoning snapshots. Never exposed on the registered tool schema. */
+	panel_reasoning?: ThinkingLevel;
+	judge_reasoning?: ThinkingLevel;
 	/** Internal/context-expanded text built by the extension from session history. */
 	context_text?: string;
 }
@@ -96,6 +140,12 @@ export interface FusionDetails {
 	failed_models?: Array<{ model: string; error: string; tools?: PanelToolUsage }>;
 	panel_models?: string[];
 	judge_model?: string;
+	/** Effective named panel, when resolution selected one. */
+	panel_profile?: string;
+	/** Requested effort and the actual effort sent to each panel model (`null` when omitted). */
+	panel_reasoning?: { requested: ThinkingLevel; effective: Record<string, ThinkingLevel | null> };
+	/** Requested judge effort and the actual effort sent (`null` when omitted). */
+	judge_reasoning?: { requested: ThinkingLevel; effective: ThinkingLevel | null };
 	/** Resolved panel tool mode + cap, when tools were enabled. */
 	panel_tools?: { mode: string; max_tool_calls: number; serialized: boolean };
 	/** Non-fatal warnings (unauthed models, tool downgrades, etc.). */

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -16,14 +16,15 @@ import {
 	Spacer,
 	Text,
 } from "@earendil-works/pi-tui";
-import { MAX_PANEL_MODELS_HARD_LIMIT } from "./config.ts";
+import { MAX_PANEL_MODELS_HARD_LIMIT, THINKING_LEVELS } from "./config.ts";
 import { modelDisplay } from "./models.ts";
 import { clampMaxToolCalls, isMutatingSelection } from "./tools.ts";
-import type { Api, FooterDisplay, Model, ToolMode } from "./types.ts";
+import type { Api, FooterDisplay, Model, ThinkingLevel, ToolMode } from "./types.ts";
 
 const TOOL_MODE_CYCLE: ToolMode[] = ["none", "readonly", "all"];
 const FOOTER_DISPLAY_CYCLE: FooterDisplay[] = ["full", "compact", "off"];
 const MAX_CALLS_PRESETS = [4, 8, 12, 16, 25, 50, 100];
+const REASONING_CYCLE = ["default", ...THINKING_LEVELS] as const;
 
 interface ModelInfo {
 	identifier: string;
@@ -33,9 +34,22 @@ interface ModelInfo {
 
 export type FusionMode = "available" | "forced" | "off";
 
+export interface FusionSetupProfile {
+	selectedIds: string[];
+	judgeId: string | undefined;
+	panelReasoning?: ThinkingLevel;
+	judgeReasoning?: ThinkingLevel;
+}
+
 export interface FusionSetupState {
 	selectedIds: Set<string>;
 	judgeId: string | undefined;
+	/** Source named panel while profile-owned values still match its snapshot. */
+	profileName?: string;
+	/** Authed named-panel snapshots available to the setup picker. */
+	profiles?: Record<string, FusionSetupProfile>;
+	panelReasoning?: ThinkingLevel;
+	judgeReasoning?: ThinkingLevel;
 	/** Legacy boolean: true => forced, false/undefined => available. */
 	enabled?: boolean;
 	mode?: FusionMode;
@@ -45,8 +59,24 @@ export interface FusionSetupState {
 	maxToolCalls?: number;
 	/** Whether the user consented to mutating panel tools this session. */
 	toolsConsented?: boolean;
-	/** Footer verbosity for this session. */
+	/** Fusion status verbosity for this session. */
 	footerDisplay?: FooterDisplay;
+}
+
+/** Copy a configured named panel into detached session/setup state. */
+export function applySetupProfile(state: FusionSetupState, profileName: string): void {
+	const profile = state.profiles?.[profileName];
+	if (!profile) return;
+	state.selectedIds = new Set(profile.selectedIds);
+	state.judgeId = profile.judgeId;
+	state.panelReasoning = profile.panelReasoning;
+	state.judgeReasoning = profile.judgeReasoning;
+	state.profileName = profileName;
+}
+
+/** Profile-owned edits turn the setup selection into a custom snapshot. */
+export function markSetupCustom(state: Pick<FusionSetupState, "profileName">): void {
+	state.profileName = undefined;
 }
 
 function toModelInfo(available: Model<Api>[]): ModelInfo[] {
@@ -131,6 +161,10 @@ export async function selectFusionSetup(
 	const state: FusionSetupState = {
 		selectedIds: new Set(initial.selectedIds),
 		judgeId: initial.judgeId,
+		profileName: initial.profileName,
+		profiles: initial.profiles,
+		panelReasoning: initial.panelReasoning,
+		judgeReasoning: initial.judgeReasoning,
 		enabled: initial.enabled ?? false,
 		panelTools: initial.panelTools ?? "none",
 		maxToolCalls: clampMaxToolCalls(initial.maxToolCalls),
@@ -145,7 +179,41 @@ export async function selectFusionSetup(
 		set: (value: string) => void;
 		note: () => string;
 	}
-	const configRows: ConfigRow[] = [
+	const configRows: ConfigRow[] = [];
+	const profileNames = Object.keys(state.profiles ?? {}).sort();
+	if (profileNames.length > 0) {
+		configRows.push({
+			label: "Named panel",
+			values: ["custom", ...profileNames],
+			get: () => state.profileName ?? "custom",
+			set: (value) => {
+				if (value === "custom") markSetupCustom(state);
+				else applySetupProfile(state, value);
+			},
+			note: () => "select a configured panel or keep a custom session snapshot",
+		});
+	}
+	configRows.push(
+		{
+			label: "Panel reasoning",
+			values: [...REASONING_CYCLE],
+			get: () => state.panelReasoning ?? "default",
+			set: (value) => {
+				state.panelReasoning = value === "default" ? undefined : value as ThinkingLevel;
+				markSetupCustom(state);
+			},
+			note: () => "reasoning effort copied into this session snapshot",
+		},
+		{
+			label: "Judge reasoning",
+			values: [...REASONING_CYCLE],
+			get: () => state.judgeReasoning ?? "default",
+			set: (value) => {
+				state.judgeReasoning = value === "default" ? undefined : value as ThinkingLevel;
+				markSetupCustom(state);
+			},
+			note: () => "judge reasoning effort copied into this session snapshot",
+		},
 		{
 			label: "Panel tools",
 			values: TOOL_MODE_CYCLE,
@@ -171,7 +239,7 @@ export async function selectFusionSetup(
 			note: () => "max tool steps per panel model when tools are on",
 		},
 		{
-			label: "Footer",
+			label: "Fusion status",
 			values: FOOTER_DISPLAY_CYCLE,
 			get: () => state.footerDisplay ?? "full",
 			set: (v) => {
@@ -179,12 +247,12 @@ export async function selectFusionSetup(
 			},
 			note: () =>
 				state.footerDisplay === "off"
-					? "restore Pi's built-in footer"
+					? "hide Fusion status"
 					: state.footerDisplay === "compact"
 						? "show only fusion mode and panel count"
 						: "show fusion mode, panel, judge, and tools",
 		},
-	];
+	);
 
 	return ctx.ui.custom<FusionSetupState | null>((tui, theme, _kb, done) => {
 		let focus: "models" | "config" = "models";
@@ -245,7 +313,8 @@ export async function selectFusionSetup(
 		function panelSummary(): string {
 			const names = Array.from(state.selectedIds).map((id) => nameById.get(id) ?? id);
 			if (names.length === 0) return dim("Panel: ") + warn("none selected (press p)");
-			return dim(`Panel (${names.length}): `) + names.join(", ");
+			const source = profileNames.length > 0 ? `, ${state.profileName ?? "custom"}` : "";
+			return dim(`Panel (${names.length}${source}): `) + names.join(", ");
 		}
 		function judgeSummary(): string {
 			const judge = state.judgeId ? (nameById.get(state.judgeId) ?? state.judgeId) : undefined;
@@ -315,6 +384,10 @@ export async function selectFusionSetup(
 			done({
 				selectedIds: new Set(state.selectedIds),
 				judgeId: state.judgeId,
+				profileName: state.profileName,
+				profiles: state.profiles,
+				panelReasoning: state.panelReasoning,
+				judgeReasoning: state.judgeReasoning,
 				enabled: state.enabled,
 				panelTools: state.panelTools,
 				maxToolCalls: state.maxToolCalls,
@@ -409,6 +482,7 @@ export async function selectFusionSetup(
 							tui.requestRender();
 						} else {
 							state.selectedIds = togglePanelMember(state.selectedIds, item.value);
+							markSetupCustom(state);
 							refresh();
 						}
 					}
@@ -418,12 +492,14 @@ export async function selectFusionSetup(
 					const item = selectList.getSelectedItem();
 					if (item) {
 						state.judgeId = toggleJudgeSelection(state.judgeId, item.value);
+						markSetupCustom(state);
 						refresh();
 					}
 					return;
 				}
 				if (data === "c") {
 					state.selectedIds = new Set();
+					markSetupCustom(state);
 					refresh();
 					return;
 				}


### PR DESCRIPTION
## Summary

Fusion users can now keep reusable named panels, choose one for a single run or from setup, and independently configure panel and judge reasoning effort. Existing single-panel configuration remains valid, while explicit unusable panels fail clearly and invalid defaults degrade through the legacy and automatic selection paths.

Fusion also stops claiming Pi's singleton footer. It publishes only its keyed status, so built-in and third-party footer extensions can render Fusion state without duplicated or clobbered UI.

Key design decisions:

- Named panels remain user-owned configuration and are not exposed to the invoking model through the `fusion` tool schema.
- Reasoning uses Pi's provider-neutral levels; unsupported effort is omitted per model with a visible warning instead of being silently substituted.
- Stateful `/fusion --panel` is interactive-only and consumed once; `/fusion-report --panel` also supports print mode because it executes directly.
- Pi peer packages now require version 0.74.0 or newer, the earliest verified line containing the required reasoning, status, session, and lifecycle APIs.

## Validation

- `npm test` — 76 tests pass.
- `npm run check` — clean.
- `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` — clean.
- `npm pack --dry-run` — 20 expected package files; tests and internal plans excluded.
- Real offline Pi smoke: `/fusion --panel` gives print-mode guidance and `/fusion-report --panel missing` returns the named-panel validation error without a provider call.
- Static verification confirms production code contains no `setFooter` call.
- Browser QA is not applicable because pi-fusion has no browser route or development server surface.

Fixes #12
Fixes #13
Fixes #14

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Codex](https://img.shields.io/badge/GPT--5-000000)
