### PR TITLE
feat: support max reasoning effort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 0.8.2
+
+- Added `max` reasoning effort for panel and judge configuration, including `/fusion-setup`. Models that support `max` receive it; lower-ceiling models keep the existing non-fatal warn-and-omit behavior without clamping.
+- Raised the minimum supported Pi peer versions to 0.80.6 and moved legacy completion/faux-provider registration to Pi's compatibility entrypoint. The model-controlled `fusion` tool schema remains unchanged.
+
 ## 0.8.1
 
 - Fixed GitHub Copilot `gpt-5.6-sol` requests failing with a 400 by omitting the unsupported `temperature` parameter for that exact provider/model pair. Other Copilot models and providers retain their existing temperature behavior.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ pi install /path/to/pi-fusion                       # from a local checkout
 
 After installing or updating in a running session, run `/reload`.
 
-There's no build step; pi loads the TypeScript directly via [jiti](https://github.com/unjs/jiti). Requires Node ≥ 22.19.0 and Pi ≥ 0.74.0.
+There's no build step; pi loads the TypeScript directly via [jiti](https://github.com/unjs/jiti). Requires Node ≥ 22.19.0 and Pi ≥ 0.80.6.
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ Generate a project-local template with `/fusion-init`, or write one by hand. Nam
       ],
       "judge": "anthropic/claude-opus-4-8",
       "panelReasoning": "high",
-      "judgeReasoning": "xhigh"
+      "judgeReasoning": "max"
     },
     "fast": {
       "models": ["openai/gpt-5.5-mini", "google/gemini-2.5-flash"],
@@ -161,7 +161,7 @@ Generate a project-local template with `/fusion-init`, or write one by hand. Nam
 | `defaultPanel` | none | Named panel used when there is no one-shot or session selection. An invalid default warns and falls through to legacy or auto selection. |
 | `panel` | auto-diverse | Legacy top-level model identifiers in `provider/id` form. Still supported; only authed models are used. |
 | `judge` | current model, then first panel model | Legacy/default judge model identifier in `provider/id` form. Named panels inherit it when they omit `judge`. |
-| `panelReasoning` | provider default | Reasoning effort for panel calls: `minimal`, `low`, `medium`, `high`, or `xhigh`. Named panels may override it. |
+| `panelReasoning` | provider default | Reasoning effort for panel calls: `minimal`, `low`, `medium`, `high`, `xhigh`, or `max`. Named panels may override it. |
 | `judgeReasoning` | provider default | Independent reasoning effort for judge synthesis, using the same levels. Named panels may override it. |
 | `maxPanelModels` | 3 | Max panel size (1–8). |
 | `maxPanelOutputTokens` | 2048 | Max tokens per panel response. |

--- a/docs/plans/2026-07-25-001-feat-max-thinking-level-plan.md
+++ b/docs/plans/2026-07-25-001-feat-max-thinking-level-plan.md
@@ -1,0 +1,221 @@
+---
+title: "Max Thinking Level Support - Plan"
+type: "feat"
+date: "2026-07-25"
+deepened: "2026-07-25"
+artifact_contract: "ce-unified-plan/v1"
+artifact_readiness: "implementation-ready"
+execution: "code"
+product_contract_source: "ce-plan-bootstrap"
+---
+
+# Max Thinking Level Support - Plan
+
+## Goal Capsule
+
+| Field | Value |
+|---|---|
+| Objective | Resolve GitHub issue #19 by accepting Pi's `max` thinking level for panel and judge reasoning while preserving user ownership and per-model fallback behavior. |
+| Authority | Issue #19, Pi 0.80.6 public contracts, repository instructions, then current Fusion reasoning patterns. |
+| Execution profile | Small public-contract change protected by configuration, runtime, type, package, and live extension verification. |
+| Stop conditions | Stop if the Pi 0.80.6 compatibility entrypoint cannot preserve the existing completion behavior or if the change would expose reasoning control to the invoking model. |
+| Tail ownership | The executor owns implementation and verification; version bumps, changelog entries, tags, and release publication remain outside this plan. |
+
+---
+
+## Product Contract
+
+### Summary
+
+Accept lowercase `max` anywhere users can configure panel or judge reasoning, expose it through the existing setup controls, and dispatch it only to models that report support.
+Align the package with the first Pi release that can type and execute `max` without expanding the model-controlled tool surface.
+
+### Problem Frame
+
+Pi added `max` to its provider-neutral `ThinkingLevel`, but Fusion's runtime validation stops at `xhigh`.
+Users can select a `:max` model in Pi yet cannot apply the same effort to `panelReasoning` or `judgeReasoning`; the configuration is rejected before Fusion reaches its existing per-model capability guard.
+
+The checkout is also locked to Pi 0.79.3, whose type and capability ladder cannot represent `max`.
+Effective support therefore requires the Pi 0.80.6 contract rather than a local parsing-only shim that would always omit the requested level at dispatch.
+
+### Requirements
+
+**Configuration and setup**
+
+- R1. Top-level and named-panel `panelReasoning` and `judgeReasoning` accept the exact lowercase value `max`.
+- R2. Both `/fusion-setup` reasoning controls cycle from `xhigh` to `max` through the same shared ordered vocabulary used by configuration validation.
+- R3. Earlier reasoning values and generated configuration defaults remain unchanged, while values such as `MAX` and `maximum` remain invalid.
+
+**Runtime behavior and control**
+
+- R4. A panel model or judge that reports `max` support receives `max`; an unsupported model receives no requested reasoning and produces the existing non-fatal warning without clamping.
+- R5. Reasoning remains user-owned configuration and is not added to the registered `fusion` tool parameters.
+
+**Compatibility and documentation**
+
+- R6. Package metadata and the reproducible install baseline require aligned Pi peers at 0.80.6 or newer, the first release line whose public type and runtime capability logic include `max`.
+- R7. The README lists `max`, the new Pi minimum, unchanged unsupported-model behavior, and the existing latency/token/cost warning.
+
+### Acceptance Examples
+
+- AE1. Given top-level `panelReasoning: "max"` and `judgeReasoning: "max"`, effective configuration preserves both values without warnings.
+- AE2. Given a named panel with `judgeReasoning: "max"` and an omitted panel override, the named panel preserves `max` for the judge and inherits the top-level panel value.
+- AE3. Given a mixed panel where one model reports `thinkingLevelMap.max` and another does not, the supported model receives `max`, the unsupported model records no effective level, and Fusion returns the existing model-specific warning.
+- AE4. Given fewer than two successful panel responses, judge synthesis is skipped and a requested judge `max` produces neither a provider call nor a support warning.
+
+### Scope Boundaries
+
+- Do not redesign reasoning configuration, introduce per-model config objects, clamp unsupported levels, or filter setup choices against the currently selected models.
+- Do not migrate Fusion from Pi's temporary compatibility completion API to the newer `Models` runtime in this issue.
+- Do not add reasoning overrides to the model-controlled `fusion` tool schema.
+- Do not change generated template defaults merely to demonstrate `max`.
+- Do not add a changelog entry, bump the Fusion version, tag, publish, or perform other release work.
+
+### Sources and Research
+
+- [GitHub issue #19](https://github.com/synthetic-recon/pi-fusion/issues/19) defines the requested behavior and identifies the existing validation boundary.
+- [Pi v0.80.6](https://github.com/earendil-works/pi/releases/tag/v0.80.6) is the first published release whose `ThinkingLevel` type and runtime capability ladder include `max`.
+- [Pi AI 0.80 migration notes](https://github.com/earendil-works/pi/blob/v0.80.6/packages/ai/CHANGELOG.md) place legacy `complete()` and faux-provider registration under `@earendil-works/pi-ai/compat`.
+- [Current Pi AI types](https://github.com/earendil-works/pi/blob/main/packages/ai/src/types.ts) and [CLI validation](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/cli/args.ts) confirm `max` but expose no universal runtime level list.
+- `docs/plans/2026-07-10-001-feat-fusion-profiles-reasoning-status-plan.md` records the user-owned reasoning and warn-without-clamping contracts this plan preserves.
+- No `CONCEPTS.md` or `docs/solutions/` corpus exists, so there are no repository solution notes to carry forward.
+
+---
+
+## Planning Contract
+
+### Key Technical Decisions
+
+- KTD1. Keep one Fusion-owned ordered thinking-level allowlist and append `max` after `xhigh`. (session-settled: user-approved — chosen over a new synchronization abstraction: Pi exposes a model-specific support query but no stable universal runtime list for pre-model configuration and setup.)
+- KTD2. Raise the aligned `@earendil-works/pi-ai`, `@earendil-works/pi-coding-agent`, and `@earendil-works/pi-tui` peer minimums to 0.80.6 and refresh the lockfile.
+  `pi-ai` owns the reasoning contract, `pi-coding-agent` supplies the registry/runtime model objects, and `pi-tui` crosses the coding-agent UI boundary, so moving the established compatibility line together avoids an untested mixed Pi graph.
+- KTD3. Import only `complete` and `registerFauxProvider` from `@earendil-works/pi-ai/compat`; keep `getSupportedThinkingLevels`, model/message types, `fauxAssistantMessage`, and `fauxToolCall` on the root import.
+  Pi 0.80 made this split a breaking package boundary, while a full migration to the new provider runtime is outside the issue.
+- KTD4. Continue using `getSupportedThinkingLevels(model)` at dispatch time and omit unsupported effort rather than calling Pi's clamp helper.
+  Configuration and setup exist before a specific model is resolved, while dispatch is the correct point for model-specific capability checks.
+- KTD5. Preserve the registered tool schema unchanged.
+  Reasoning changes cost, latency, and quality, so the invoking model must not override user-owned panel or judge settings.
+
+### High-Level Technical Design
+
+The shared vocabulary remains the single pre-model source for configuration and setup:
+
+```mermaid
+flowchart TB
+  A["Pi 0.80.6+ ThinkingLevel type"] --> B["Fusion THINKING_LEVELS"]
+  B --> C["Top-level and named-panel validation"]
+  B --> D["Panel reasoning setup cycle"]
+  B --> E["Judge reasoning setup cycle"]
+  C --> F["Resolved user-owned reasoning"]
+  D --> F
+  E --> F
+```
+
+Runtime support stays model-specific and preserves the current failure mode:
+
+```mermaid
+flowchart TB
+  A["Resolved panel or judge reasoning"] --> B["getSupportedThinkingLevels(model)"]
+  B --> C{"Requested max supported?"}
+  C -->|yes| D["Pass max to compat complete()"]
+  C -->|no| E["Omit reasoning"]
+  E --> F["Append existing non-fatal warning"]
+  D --> G["Panel response or judge synthesis"]
+  F --> G
+```
+
+### System-Wide Impact
+
+| Surface | Planned effect | Invariant |
+|---|---|---|
+| Config validation | Accept `max` at top level and in named panels. | Invalid values still fail or warn through existing paths. |
+| Setup UI | Both reasoning rows gain `max` through the shared sequence. | Session snapshot and custom-selection behavior remain unchanged. |
+| Panel execution | Resolve support independently for every model. | Mixed panels continue after unsupported requests with deterministic warnings. |
+| Judge execution | Apply the same support guard only when synthesis runs. | A skipped judge produces no call and no judge-support warning. |
+| Tool schema | No new reasoning input. | Panel, judge, reasoning, tools, and budgets remain user-owned. |
+| Package compatibility | Move to aligned Pi 0.80.6+ peers and the compatibility completion entrypoint. | Keep `dependencies: {}` and avoid a broader provider-runtime migration. |
+
+### Risks and Dependencies
+
+- **Pi's compatibility entrypoint is explicitly transitional.** Keep the import migration narrow, verify minimum and current Pi releases, and defer the larger `Models` migration to separate work.
+  Retain the repository's established open-ended peer policy consciously: minimum/current checks cover known releases, while removal of `/compat` in a future admitted release is the boundary that triggers the separate migration rather than an assurance this plan can make in advance.
+- **A global `max` choice is not universal model support.** Preserve per-model resolution and cover both supported and unsupported paths so the UI does not imply silent clamping.
+- **Raising the peer floor drops older Pi installations.** Document the new minimum and use 0.80.6 because earlier releases cannot fulfill the feature's public type or effective runtime contract.
+- **The shared allowlist can drift if Pi adds another level.** Keep it adjacent to the imported `ThinkingLevel` contract, test its ordered contents, and avoid importing private CLI constants.
+
+---
+
+## Implementation Units
+
+### U1. Align the Pi compatibility baseline
+
+- **Goal:** Establish a type-correct and runtime-compatible Pi 0.80.6+ baseline before adding `max`.
+- **Requirements:** R6, R7; KTD2, KTD3
+- **Dependencies:** None
+- **Files:** `package.json`, `package-lock.json`, `src/llm.ts`, `src/__tests__/llm.test.ts`, `README.md`
+- **Approach:**
+  1. Raise all three Pi peer minimums together and refresh the reproducible peer resolution while keeping the package dependency-free.
+  2. Split the legacy completion import and faux-provider test registration onto Pi's compatibility entrypoint, leaving model types and capability helpers on the root API.
+  3. Update the documented Pi minimum without changing Fusion's version or changelog.
+- **Execution note:** Prove extension loading and the existing LLM tests against the new import boundary before changing the reasoning vocabulary.
+- **Patterns to follow:** The aligned Pi peer ranges in `package.json`; the documented Pi API import boundaries; the current fake-provider test lifecycle.
+- **Test scenarios:**
+  1. Loading the extension with aligned Pi 0.80.6 peers resolves both the root API and `/compat` entrypoint without an export error.
+  2. The existing raw-completion and faux-provider tests behave unchanged after the import split.
+  3. Type checking sees `max` in Pi's exported `ThinkingLevel`.
+  4. The package manifest still has an empty `dependencies` object and aligned peer minimums.
+- **Verification:** The extension loads, existing focused LLM tests pass, and package/type checks report no compatibility regression before U2 begins.
+
+### U2. Accept and dispatch max reasoning
+
+- **Goal:** Add `max` to every user-owned reasoning surface and prove supported and unsupported runtime behavior.
+- **Requirements:** R1, R2, R3, R4, R5, R7; AE1, AE2, AE3, AE4; KTD1, KTD4, KTD5
+- **Dependencies:** U1
+- **Files:** `src/config.ts`, `src/__tests__/config.test.ts`, `src/__tests__/llm.test.ts`, `src/__tests__/fusion.test.ts`, `src/__tests__/index.test.ts`, `README.md`
+- **Approach:**
+  1. Append `max` to the shared ordered configuration vocabulary so existing top-level, named-panel, warning-text, and setup-cycle consumers inherit it.
+  2. Keep production dispatch unchanged and strengthen regression coverage at its existing configuration, model-capability, extension-registration, panel, judge, and tool-loop seams.
+  3. Update the accepted-value documentation and one judge example while preserving the unsupported-model and cost guidance.
+- **Execution note:** Add focused failing configuration and runtime assertions before extending the shared allowlist.
+- **Patterns to follow:** `THINKING_LEVELS` and `isThinkingLevel()` in `src/config.ts`; `REASONING_CYCLE` in `src/ui.ts`; `resolveModelReasoning()` in `src/llm.ts`; ordered panel resolution in `src/fusion.ts`.
+- **Test scenarios:**
+  1. Top-level panel and judge `max` values survive normalization with no warning.
+  2. Explicit and default named-panel selection accept independent `max` overrides and preserve omitted-role inheritance.
+  3. The shared ordered vocabulary ends with `xhigh`, `max`, while `MAX` and `maximum` retain existing invalid-value behavior and messages now list `max`.
+  4. A model advertising `thinkingLevelMap.max` resolves and receives `max`; a reasoning model without that mapping receives no requested level and emits the existing warning.
+  5. A `runFusion()` integration test registers one panel model with explicit `max` support, one lower-ceiling model whose explicit map omits `max`, and a supported judge; provider callbacks record the requested reasoning, both panelists succeed in order with effective levels `max` and `null`, only the lower-ceiling model warns, and the judge receives `max`.
+  6. Initial and forced-final tool-loop completions both retain supported `max`.
+  7. A separate single-success `runFusion()` case uses an unsupported judge and asserts zero judge callbacks, no effective judge reasoning details, and no judge-support warning.
+  8. Extension-registration coverage captures the existing `registerTool` input and confirms the `fusion` schema remains exactly `prompt`, `context_mode`, and `context_turns`, without exporting private parameter types for testing.
+- **Verification:** Both user roles can select `max`, supported models receive it unchanged, unsupported models degrade visibly, and prior reasoning levels and configuration defaults remain stable.
+
+---
+
+## Verification Contract
+
+| Gate | Command or environment | Proves |
+|---|---|---|
+| Minimum Pi compatibility | In a disposable copy, install exact 0.80.6 versions of all three Pi peers without persisting manifest or lock changes; run `npm run check`, the strict TypeScript pass, and `npm test`. | The declared floor exports `max`, shares faux-provider registration with compatibility completion, and executes the full contract. |
+| Current Pi compatibility | In a separate disposable copy, install exact current versions of all three aligned Pi peers without persisting manifest or lock changes; run the same type and test gates. | The transitional import and reasoning contract still work on the newest known supported peers without mutating the canonical lockfile. |
+| Focused configuration | `node --import jiti/register src/__tests__/config.test.ts` | Top-level/named validation, inheritance, invalid values, and ordered vocabulary. |
+| Focused runtime and schema | Run `src/__tests__/llm.test.ts`, `src/__tests__/fusion.test.ts`, and `src/__tests__/index.test.ts` individually through `node --import jiti/register`. | Root/compat imports, supported/unsupported panel and judge dispatch, tool-loop propagation, and unchanged model-controlled tool parameters. |
+| Full regression suite | `npm test` | Existing extension behavior remains intact. |
+| Type checks | `npm run check` and `npx tsc --noEmit --noUnusedLocals --noUnusedParameters` | Public types, import boundaries, and dead-code discipline are sound. |
+| Package surface | `npm pkg get peerDependencies dependencies` and `npm pack --dry-run` | All Pi peer floors are aligned, runtime dependencies remain empty, and the published source/docs are complete without test leakage. |
+| Live extension smoke | `pi -e .` | The extension loads and `/fusion-setup` exposes `max` for both reasoning rows under real Pi resolution. |
+
+---
+
+## Definition of Done
+
+- U1 and U2 satisfy every cited requirement and acceptance example.
+- Top-level and named-panel panel/judge reasoning accept exact lowercase `max`.
+- Setup exposes `max` through the shared panel and judge cycles without new UI state.
+- Supported panel and judge models receive `max`; unsupported models omit it with the existing deterministic warning and no clamping.
+- The invoking model cannot select reasoning through the `fusion` tool schema.
+- Aligned Pi peer metadata requires 0.80.6 or newer, the lockfile reproduces a compatible install, and the package remains dependency-free.
+- The Pi root and compatibility imports match their documented ownership and pass minimum/current extension-load checks.
+- README configuration, examples, compatibility floor, fallback behavior, and cost guidance match the implementation.
+- Minimum/current compatibility gates, focused tests, the full suite, both TypeScript checks, manifest inspection, and package dry-run pass unconditionally.
+- The live `pi -e .` setup smoke passes when an interactive authenticated Pi environment is available; otherwise the executor records the missing environment and an explicit manual follow-up.
+- No changelog entry, Fusion version bump, release tag, publication step, provider-runtime redesign, temporary diagnostics, or abandoned compatibility shim remains in the diff.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
         "node": ">=22.19.0"
       },
       "peerDependencies": {
-        "@earendil-works/pi-ai": ">=0.74.0",
-        "@earendil-works/pi-coding-agent": ">=0.74.0",
-        "@earendil-works/pi-tui": ">=0.74.0",
+        "@earendil-works/pi-ai": ">=0.80.6",
+        "@earendil-works/pi-coding-agent": ">=0.80.6",
+        "@earendil-works/pi-tui": ">=0.80.6",
         "typebox": "*"
       }
     },
@@ -531,16 +531,17 @@
       }
     },
     "node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.3.tgz",
-      "integrity": "sha512-lMSput/haP5uZAGbXhS5rAYd3GB7GYdJkoAUxg3VFummBeqGqGqllaTWrbHFN12kVGyVfWHhdySNXkiqVh65Iw==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
+      "integrity": "sha512-3WFYRhEp3lQB3444EhPMBcM7zSaEUE3eJgHOR7s4081NLqbw/FsWilIKWXSua0Gv3sRr7m9xMidR3pPDE7jI/A==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -563,16 +564,16 @@
       "peer": true
     },
     "node_modules/@earendil-works/pi-coding-agent": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.79.3.tgz",
-      "integrity": "sha512-B3rAyw4/f1l3EYjQpCKpevzuBIPjYor6fHxPHQpLMdn/NTv3536i1P4ZrsyFkKpXqJWH66xKK5hyf8sqRe3dGA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-coding-agent/-/pi-coding-agent-0.82.1.tgz",
+      "integrity": "sha512-zbkAhoIuDPMF3pKuja0ajZabrMWU29FUMV9A/XMXT/XC1yXs5xt6t6t13GogQFsDrDqbFP4DkZQO1w8rWRAzYA==",
       "hasShrinkwrap": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@earendil-works/pi-agent-core": "^0.79.3",
-        "@earendil-works/pi-ai": "^0.79.3",
-        "@earendil-works/pi-tui": "^0.79.3",
+        "@earendil-works/pi-agent-core": "^0.82.1",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "@earendil-works/pi-tui": "^0.82.1",
         "@silvia-odwyer/photon-node": "0.3.4",
         "chalk": "5.6.2",
         "cross-spawn": "7.0.6",
@@ -584,8 +585,9 @@
         "jiti": "2.7.0",
         "minimatch": "10.2.5",
         "proper-lockfile": "4.1.2",
+        "semver": "7.8.0",
         "typebox": "1.1.38",
-        "undici": "8.3.0",
+        "undici": "8.5.0",
         "yaml": "2.9.0"
       },
       "bin": {
@@ -1061,12 +1063,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-agent-core": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.79.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-agent-core/-/pi-agent-core-0.82.1.tgz",
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "@earendil-works/pi-ai": "^0.79.3",
+        "@earendil-works/pi-ai": "^0.82.1",
+        "diff": "8.0.4",
         "ignore": "7.0.5",
         "typebox": "1.1.38",
         "yaml": "2.9.0"
@@ -1076,15 +1079,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-ai": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.79.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-ai/-/pi-ai-0.82.1.tgz",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@anthropic-ai/sdk": "0.91.1",
         "@aws-sdk/client-bedrock-runtime": "3.1048.0",
         "@google/genai": "1.52.0",
-        "@mistralai/mistralai": "2.2.1",
+        "@mistralai/mistralai": "2.2.6",
+        "@opentelemetry/api": "1.9.0",
         "@smithy/node-http-handler": "4.7.3",
         "http-proxy-agent": "7.0.2",
         "https-proxy-agent": "7.0.6",
@@ -1100,13 +1104,13 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.3.tgz",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -1328,15 +1332,24 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@nodable/entities": {
@@ -1351,6 +1364,26 @@
       ],
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.41.1",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.41.1.tgz",
+      "integrity": "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -1374,9 +1407,9 @@
       "peer": true
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/eventemitter": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz",
-      "integrity": "sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -1394,13 +1427,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "peer": true
-    },
-    "node_modules/@earendil-works/pi-coding-agent/node_modules/@protobufjs/inquire": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.2.tgz",
-      "integrity": "sha512-pa0vFRuws4wkvaXKK1uXZMAwAX4/t8ANaJo45iw/oQHNQ9q5xUzwgFmVJGXiga2BeN+zpX7Vf9vmsiIa2J+MUw==",
       "license": "BSD-3-Clause",
       "peer": true
     },
@@ -1630,9 +1656,9 @@
       "peer": true
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.7",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
+      "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -2047,16 +2073,16 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/minimatch": {
@@ -2248,9 +2274,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/protobufjs": {
-      "version": "7.5.9",
-      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.9.tgz",
-      "integrity": "sha512-Od4muIm3HW1AouyHF5lONOf1FWo3hY1NbFDoy191X9GzhpgW1clCoaFjfVs2rKJNFYpTNJbje4cbAIDBZJ63ZA==",
+      "version": "7.6.5",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.5.tgz",
+      "integrity": "sha512-/FPD0nUc9jH6rfFjji9IBqOz4pcSE3CsT1m7Ep6Mdb0LxSUMj8hgl6GomOvZzpNpAqqGaXA0P3VSrZLFzIhQrw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
       "peer": true,
@@ -2258,15 +2284,14 @@
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",
         "@protobufjs/codegen": "^2.0.5",
-        "@protobufjs/eventemitter": "^1.1.0",
+        "@protobufjs/eventemitter": "^1.1.1",
         "@protobufjs/fetch": "^1.1.1",
         "@protobufjs/float": "^1.0.2",
-        "@protobufjs/inquire": "^1.1.2",
         "@protobufjs/path": "^1.1.2",
         "@protobufjs/pool": "^1.1.0",
         "@protobufjs/utf8": "^1.1.1",
         "@types/node": ">=13.7.0",
-        "long": "^5.0.0"
+        "long": "^5.3.2"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2302,6 +2327,19 @@
       ],
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@earendil-works/pi-coding-agent/node_modules/semver": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.0.tgz",
+      "integrity": "sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==",
+      "license": "ISC",
+      "peer": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/shebang-command": {
       "version": "2.0.0",
@@ -2368,9 +2406,9 @@
       "peer": true
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/undici": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-8.3.0.tgz",
-      "integrity": "sha512-TkUDgb6tl7KOGZ+7e8E3d2FYgUQgF6z5YypqjWmixVQSQERFcVrVg0ySADm2LVLRh5ljAaHTCR5Fmz3Q34rB7Q==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-8.5.0.tgz",
+      "integrity": "sha512-xamtWoB1EshgjpmlXd7GGm2VfdDtw1+rD8uhry8pSNW3If6S8E0m2T2+orSKeZXEn/aPJMviCpDBA65WJt8zhg==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2411,9 +2449,9 @@
       }
     },
     "node_modules/@earendil-works/pi-coding-agent/node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -2485,14 +2523,14 @@
       }
     },
     "node_modules/@earendil-works/pi-tui": {
-      "version": "0.79.3",
-      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.79.3.tgz",
-      "integrity": "sha512-cpmkEM1aEuGUx6YZM36VlzpulwLzqD5T2cUEkGHndDTNGEbnn5sj/9SYm+QBfKjvZsWoHfZuFBnu4+hh96/FbA==",
+      "version": "0.82.1",
+      "resolved": "https://registry.npmjs.org/@earendil-works/pi-tui/-/pi-tui-0.82.1.tgz",
+      "integrity": "sha512-9yN8hALfKaxZq7n54EMxqhFCWnMi6LHkraMJ/1YjHiATq75XrI6XDMVppn9EDtiK7Fks8hUe1SDXUTrIvwRWfQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "get-east-asian-width": "1.6.0",
-        "marked": "15.0.12"
+        "marked": "18.0.5"
       },
       "engines": {
         "node": ">=22.19.0"
@@ -2524,15 +2562,24 @@
       }
     },
     "node_modules/@mistralai/mistralai": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.1.tgz",
-      "integrity": "sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@mistralai/mistralai/-/mistralai-2.2.6.tgz",
+      "integrity": "sha512-W8pX7zHxjJvMIpw8JMxeJEleapXX0Q9NPszdNzqkM3MIEoIGPObdodujj+WHteXEvGfaP/AMwlNyRfEzSY6dQQ==",
       "license": "Apache-2.0",
       "peer": true,
       "dependencies": {
+        "@opentelemetry/semantic-conventions": "^1.40.0",
         "ws": "^8.18.0",
         "zod": "^3.25.0 || ^4.0.0",
         "zod-to-json-schema": "^3.25.0"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.9.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        }
       }
     },
     "node_modules/@nodable/entities": {
@@ -2547,6 +2594,26 @@
       ],
       "license": "MIT",
       "peer": true
+    },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/@opentelemetry/semantic-conventions": {
+      "version": "1.43.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.43.0.tgz",
+      "integrity": "sha512-eSYWTm620tTk45EKSedaUL8MFYI8hW164hIXsgIHyxu3VobUB3fFCu5t0hQby6OoWRPsG1KkKUG2M5UadiLiVg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "engines": {
+        "node": ">=14"
+      }
     },
     "node_modules/@protobufjs/aspromise": {
       "version": "1.1.2",
@@ -3113,16 +3180,16 @@
       "peer": true
     },
     "node_modules/marked": {
-      "version": "15.0.12",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-15.0.12.tgz",
-      "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
+      "version": "18.0.5",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-18.0.5.tgz",
+      "integrity": "sha512-S6GcvALHg6K4ohtu4E7x0a1AqhAjp6cV8KhLSyN9qVapnzJkusVBxZRcIU9AeYsbe6P1hKDusSbEOzGyyuce6w==",
       "license": "MIT",
       "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/ms": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fusion",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fusion",
-      "version": "0.8.1",
+      "version": "0.8.2",
       "license": "MIT",
       "devDependencies": {
         "jiti": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -44,9 +44,9 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@earendil-works/pi-ai": ">=0.74.0",
-    "@earendil-works/pi-coding-agent": ">=0.74.0",
-    "@earendil-works/pi-tui": ">=0.74.0",
+    "@earendil-works/pi-ai": ">=0.80.6",
+    "@earendil-works/pi-coding-agent": ">=0.80.6",
+    "@earendil-works/pi-tui": ">=0.80.6",
     "typebox": "*"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fusion",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Multi-model deliberation for pi, inspired by OpenRouter Fusion",
   "type": "module",
   "main": "./src/index.ts",

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -7,6 +7,7 @@ import {
 	generateConfigExample,
 	parseFusionConfig,
 	resolveEffectiveConfig,
+	THINKING_LEVELS,
 } from "../config.ts";
 import type { FusionConfig } from "../types.ts";
 import { eq, test } from "./_harness.ts";
@@ -129,6 +130,54 @@ test("invalid top-level reasoning is omitted with deterministic warnings", () =>
 	eq(result.config.panelReasoning, undefined, "invalid panel effort omitted");
 	eq(result.config.judgeReasoning, undefined, "invalid judge effort omitted");
 	eq(result.warnings.length, 2, "both invalid efforts warn");
+});
+
+test("max reasoning is accepted at top level and in named panels", () => {
+	const config: FusionConfig = {
+		panelReasoning: "max",
+		judgeReasoning: "max",
+		panels: {
+			explicit: {
+				models: ["provider/panel"],
+				judgeReasoning: "max",
+			},
+			default: {
+				models: ["provider/panel"],
+				panelReasoning: "max",
+			},
+		},
+		defaultPanel: "default",
+	};
+
+	const explicit = resolveEffectiveConfig(config, {}, "explicit");
+	if (!explicit.ok) throw new Error(explicit.error.message);
+	eq(explicit.config.panelReasoning, "max", "explicit panel inherits top-level max");
+	eq(explicit.config.judgeReasoning, "max", "explicit panel preserves judge max");
+	eq(explicit.warnings, [], "valid explicit max values do not warn");
+
+	const selectedDefault = resolveEffectiveConfig(config);
+	if (!selectedDefault.ok) throw new Error(selectedDefault.error.message);
+	eq(selectedDefault.config.panelReasoning, "max", "default panel preserves panel max");
+	eq(selectedDefault.config.judgeReasoning, "max", "default panel inherits top-level judge max");
+	eq(selectedDefault.warnings, [], "valid default max values do not warn");
+});
+
+test("thinking levels remain ordered and reject non-canonical max spellings", () => {
+	eq(THINKING_LEVELS, ["minimal", "low", "medium", "high", "xhigh", "max"], "shared reasoning order");
+
+	const config = {
+		panelReasoning: "MAX",
+		judgeReasoning: "maximum",
+	} as unknown as FusionConfig;
+	const result = resolveEffectiveConfig(config);
+	if (!result.ok) throw new Error(result.error.message);
+
+	eq(result.config.panelReasoning, undefined, "uppercase max remains invalid");
+	eq(result.config.judgeReasoning, undefined, "maximum remains invalid");
+	eq(result.warnings, [
+		"Invalid panelReasoning value; omitting it. Expected minimal, low, medium, high, xhigh, max.",
+		"Invalid judgeReasoning value; omitting it. Expected minimal, low, medium, high, xhigh, max.",
+	], "invalid warnings list the canonical ordered values");
 });
 
 test("effective selection preserves applyDefaults overrides and numeric config", () => {

--- a/src/__tests__/fusion.test.ts
+++ b/src/__tests__/fusion.test.ts
@@ -2,7 +2,13 @@
  * Tests for pi-fusion pipeline helpers.
  */
 
-import { emptyPanelError, resolveFusionSelection, resolvePanelReasoning } from "../fusion.ts";
+import { fauxAssistantMessage } from "@earendil-works/pi-ai";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { emptyPanelError, resolveFusionSelection, resolvePanelReasoning, runFusion } from "../fusion.ts";
+import type { Api, Model, ThinkingLevel } from "../types.ts";
 import { eq, fakeModel, test } from "./_harness.ts";
 
 test("emptyPanelError treats non-empty content as success", () => {
@@ -34,6 +40,13 @@ function registryFor(models: ReturnType<typeof fakeModel>[], authed: Set<string>
 			return authed.has(`${model.provider}/${model.id}`);
 		},
 	} as any;
+}
+
+function trustedProjectConfig(): string {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fusion-test-"));
+	mkdirSync(join(cwd, ".pi"));
+	writeFileSync(join(cwd, ".pi", "fusion.json"), "{}");
+	return cwd;
 }
 
 test("selection preview exposes named panel metadata from the shared boundary", async () => {
@@ -130,15 +143,174 @@ test("zero-auth default falls through to legacy with warnings and no auto substi
 });
 
 test("panel reasoning support is resolved deterministically in panel order", () => {
-	const supported = fakeModel("openai", "reasoner", { reasoning: true });
-	const unsupported = fakeModel("plain", "model");
-	const result = resolvePanelReasoning([supported, unsupported], "high");
+	const supported = fakeModel("openai", "reasoner", {
+		reasoning: true,
+		thinkingLevelMap: { max: "max" },
+	});
+	const unsupported = fakeModel("plain", "model", {
+		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh" },
+	});
+	const result = resolvePanelReasoning([supported, unsupported], "max");
 
 	eq(result.effective, {
-		"openai/reasoner": "high",
+		"openai/reasoner": "max",
 		"plain/model": null,
 	}, "effective reasoning is recorded per model");
 	eq(result.warnings, [
-		"Reasoning high is not supported by plain/model; running that model without requested reasoning.",
+		"Reasoning max is not supported by plain/model; running that model without requested reasoning.",
 	], "warnings follow panel order before concurrent calls");
+});
+
+test("runFusion dispatches max per model and preserves warning order", async () => {
+	const unique = Math.random().toString(36).slice(2);
+	const provider = `fusion-max-${unique}`;
+	const registration = registerFauxProvider({
+		api: `fusion-max-api-${unique}`,
+		provider,
+		models: [
+			{ id: "panel-max", reasoning: true },
+			{ id: "panel-lower", reasoning: true },
+			{ id: "judge-max", reasoning: true },
+		],
+	});
+	const panelMax = registration.getModel("panel-max") as Model<Api>;
+	const panelLower = registration.getModel("panel-lower") as Model<Api>;
+	const judgeMax = registration.getModel("judge-max") as Model<Api>;
+	panelMax.thinkingLevelMap = { max: "max" };
+	panelLower.thinkingLevelMap = { xhigh: "xhigh" };
+	judgeMax.thinkingLevelMap = { max: "max" };
+
+	const seen: Array<{ model: string; reasoning: ThinkingLevel | undefined }> = [];
+	const record = (text: string) => (
+		_context: unknown,
+		options: unknown,
+		_state: unknown,
+		model: Model<Api>,
+	) => {
+		const reasoning = (options as { reasoning?: ThinkingLevel } | undefined)?.reasoning;
+		seen.push({ model: model.id, reasoning });
+		return fauxAssistantMessage(text);
+	};
+	registration.setResponses([
+		record("supported panel answer"),
+		record("lower-ceiling panel answer"),
+		record(JSON.stringify({
+			consensus: [],
+			contradictions: [],
+			partial_coverage: [],
+			unique_insights: [],
+			blind_spots: [],
+		})),
+	]);
+
+	const cwd = trustedProjectConfig();
+	const registry = {
+		...registryFor([panelMax, panelLower, judgeMax] as ReturnType<typeof fakeModel>[]),
+		async getApiKeyAndHeaders() {
+			return { ok: true, apiKey: "test" };
+		},
+	} as any;
+
+	try {
+		const result = await runFusion(
+			cwd,
+			registry,
+			undefined,
+			"compare",
+			true,
+			{
+				analysis_models: [`${provider}/panel-max`, `${provider}/panel-lower`],
+				model: `${provider}/judge-max`,
+				panel_reasoning: "max",
+				judge_reasoning: "max",
+			},
+			{} as any,
+			false,
+			undefined,
+		);
+
+		eq(seen, [
+			{ model: "panel-max", reasoning: "max" },
+			{ model: "panel-lower", reasoning: undefined },
+			{ model: "judge-max", reasoning: "max" },
+		], "panel and judge calls receive only supported max reasoning");
+		eq(result.details.responses.map((response) => response.model), [
+			`${provider}/panel-max`,
+			`${provider}/panel-lower`,
+		], "successful responses retain configured panel order");
+		eq(result.details.panel_reasoning, {
+			requested: "max",
+			effective: {
+				[`${provider}/panel-max`]: "max",
+				[`${provider}/panel-lower`]: null,
+			},
+		}, "panel diagnostics record supported and omitted max");
+		eq(result.details.judge_reasoning, {
+			requested: "max",
+			effective: "max",
+		}, "judge diagnostics record supported max");
+		eq(result.details.warnings, [
+			`Reasoning max is not supported by ${provider}/panel-lower; running that model without requested reasoning.`,
+		], "only the lower-ceiling panel warns");
+	} finally {
+		registration.unregister();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("single panel success skips unsupported max judge without warning", async () => {
+	const unique = Math.random().toString(36).slice(2);
+	const provider = `fusion-skip-${unique}`;
+	const registration = registerFauxProvider({
+		api: `fusion-skip-api-${unique}`,
+		provider,
+		models: [
+			{ id: "panel" },
+			{ id: "judge-lower", reasoning: true },
+		],
+	});
+	const panel = registration.getModel("panel") as Model<Api>;
+	const judge = registration.getModel("judge-lower") as Model<Api>;
+	judge.thinkingLevelMap = { xhigh: "xhigh" };
+	const seen: string[] = [];
+	registration.setResponses([
+		(_context, _options, _state, model) => {
+			seen.push(model.id);
+			return fauxAssistantMessage("only panel answer");
+		},
+	]);
+
+	const cwd = trustedProjectConfig();
+	const registry = {
+		...registryFor([panel, judge] as ReturnType<typeof fakeModel>[]),
+		async getApiKeyAndHeaders() {
+			return { ok: true, apiKey: "test" };
+		},
+	} as any;
+
+	try {
+		const result = await runFusion(
+			cwd,
+			registry,
+			undefined,
+			"single",
+			true,
+			{
+				analysis_models: [`${provider}/panel`],
+				model: `${provider}/judge-lower`,
+				judge_reasoning: "max",
+			},
+			{} as any,
+			false,
+			undefined,
+		);
+
+		eq(seen, ["panel"], "judge provider is never called");
+		eq(result.details.judge_reasoning, undefined, "skipped judge has no reasoning diagnostics");
+		eq(result.details.warnings, undefined, "skipped unsupported judge does not warn");
+	} finally {
+		registration.unregister();
+		rmSync(cwd, { recursive: true, force: true });
+	}
 });

--- a/src/__tests__/fusion.test.ts
+++ b/src/__tests__/fusion.test.ts
@@ -25,7 +25,7 @@ test("emptyPanelError attributes a capped empty to the loop guard/budget", () =>
 	eq(emptyPanelError("", true), "no text answer (tool-call budget or loop guard hit)", "capped + empty");
 });
 
-function registryFor(models: ReturnType<typeof fakeModel>[], authed: Set<string> = new Set(models.map((m) => `${m.provider}/${m.id}`))) {
+function registryFor(models: Model<Api>[], authed: Set<string> = new Set(models.map((m) => `${m.provider}/${m.id}`))) {
 	return {
 		find(provider: string, id: string) {
 			return models.find((m) => m.provider === provider && m.id === id);
@@ -36,7 +36,7 @@ function registryFor(models: ReturnType<typeof fakeModel>[], authed: Set<string>
 		getAvailable() {
 			return models.filter((m) => authed.has(`${m.provider}/${m.id}`));
 		},
-		hasConfiguredAuth(model: ReturnType<typeof fakeModel>) {
+		hasConfiguredAuth(model: Model<Api>) {
 			return authed.has(`${model.provider}/${model.id}`);
 		},
 	} as any;
@@ -206,7 +206,7 @@ test("runFusion dispatches max per model and preserves warning order", async () 
 
 	const cwd = trustedProjectConfig();
 	const registry = {
-		...registryFor([panelMax, panelLower, judgeMax] as ReturnType<typeof fakeModel>[]),
+		...registryFor([panelMax, panelLower, judgeMax]),
 		async getApiKeyAndHeaders() {
 			return { ok: true, apiKey: "test" };
 		},
@@ -283,7 +283,7 @@ test("single panel success skips unsupported max judge without warning", async (
 
 	const cwd = trustedProjectConfig();
 	const registry = {
-		...registryFor([panel, judge] as ReturnType<typeof fakeModel>[]),
+		...registryFor([panel, judge]),
 		async getApiKeyAndHeaders() {
 			return { ok: true, apiKey: "test" };
 		},

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -50,6 +50,26 @@ test("parsePanelCommand rejects missing panel names and prompts", () => {
 	if (!missingPrompt.error.includes("prompt")) throw new Error(`unexpected error: ${missingPrompt.error}`);
 });
 
+test("fusion tool schema exposes only prompt and context controls", () => {
+	let parameters: unknown;
+	registerFusionExtension({
+		registerTool(tool: { parameters: unknown }) {
+			parameters = tool.parameters;
+		},
+		registerCommand() {},
+		on() {},
+		getThinkingLevel: () => "off",
+	} as never);
+
+	const properties = (parameters as { properties?: Record<string, unknown> } | undefined)?.properties;
+	if (!properties) throw new Error("expected fusion tool parameters");
+	eq(
+		Object.keys(properties),
+		["prompt", "context_mode", "context_turns"],
+		"model-controlled schema remains user-configuration-free",
+	);
+});
+
 test("pending panel is session-bound, agent-bound, and consumed once", () => {
 	let pending: PendingPanelSelection | undefined = armPendingPanel("fast", "session-a");
 	eq(consumePendingPanel(pending, "session-a"), { panelName: undefined, pending }, "not consumed before agent start");

--- a/src/__tests__/llm.test.ts
+++ b/src/__tests__/llm.test.ts
@@ -2,7 +2,8 @@
  * Tests for provider/model request compatibility.
  */
 
-import { fauxAssistantMessage, fauxToolCall, registerFauxProvider } from "@earendil-works/pi-ai";
+import { fauxAssistantMessage, fauxToolCall } from "@earendil-works/pi-ai";
+import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { buildCompleteOptions, callModelWithTools, getSupportsTemperature, resolveModelReasoning } from "../llm.ts";
 import type { Api, Model, ThinkingLevel } from "../types.ts";
 import { eq, fakeModel, test } from "./_harness.ts";

--- a/src/__tests__/llm.test.ts
+++ b/src/__tests__/llm.test.ts
@@ -35,15 +35,19 @@ test("ordinary openai-compatible model keeps temperature", () => {
 test("resolveModelReasoning preserves supported effort and omits unsupported effort", () => {
 	const supported = fakeModel("openai", "reasoner", {
 		reasoning: true,
+		thinkingLevelMap: { xhigh: "xhigh", max: "max" },
+	});
+	const unsupported = fakeModel("openai", "lower-ceiling", {
+		reasoning: true,
 		thinkingLevelMap: { xhigh: "xhigh" },
 	});
-	const unsupported = fakeModel("openai", "plain");
 
 	eq(resolveModelReasoning(supported, "xhigh"), { requested: "xhigh", effective: "xhigh" }, "supported xhigh");
-	eq(resolveModelReasoning(unsupported, "high"), {
-		requested: "high",
-		warning: "Reasoning high is not supported by openai/plain; running that model without requested reasoning.",
-	}, "unsupported reasoning is omitted with a model-specific warning");
+	eq(resolveModelReasoning(supported, "max"), { requested: "max", effective: "max" }, "supported max");
+	eq(resolveModelReasoning(unsupported, "max"), {
+		requested: "max",
+		warning: "Reasoning max is not supported by openai/lower-ceiling; running that model without requested reasoning.",
+	}, "unsupported max is omitted without clamping");
 	eq(resolveModelReasoning(supported, undefined), {}, "unset reasoning is unchanged");
 });
 
@@ -93,7 +97,7 @@ test("completion options keep temperature for gpt-5.6-sol under another provider
 	eq(options.temperature, 0.3, "same model id under another provider retains temperature");
 });
 
-test("tool-loop finalization reuses reasoning on every raw completion", async () => {
+test("tool-loop finalization reuses max reasoning on every raw completion", async () => {
 	const registration = registerFauxProvider({
 		api: `fusion-reasoning-${Date.now()}`,
 		provider: "fusion-test",
@@ -130,12 +134,12 @@ test("tool-loop finalization reuses reasoning on every raw completion", async ()
 			1,
 			{} as any,
 			(event) => toolEvents.push(event.name),
-			"high",
+			"max",
 		);
 	} finally {
 		registration.unregister();
 	}
 
-	eq(seen, ["high", "high"], "initial and forced-final completions share reasoning");
+	eq(seen, ["max", "max"], "initial and forced-final completions share max reasoning");
 	eq(toolEvents, ["probe"], "existing callback position remains compatible");
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,7 @@ export const MAX_TOOL_CALLS = 100;
 /** Per tool result, before it re-enters the loop transcript (keeps panel context bounded). */
 export const TOOL_OUTPUT_MAX_BYTES = 12_000;
 
-export const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh"] as const;
+export const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
 
 export interface FusionConfigOverrides {
 	max_completion_tokens?: number;

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,7 +29,7 @@ export const MAX_TOOL_CALLS = 100;
 /** Per tool result, before it re-enters the loop transcript (keeps panel context bounded). */
 export const TOOL_OUTPUT_MAX_BYTES = 12_000;
 
-export const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const;
+export const THINKING_LEVELS = ["minimal", "low", "medium", "high", "xhigh", "max"] as const satisfies readonly ThinkingLevel[];
 
 export interface FusionConfigOverrides {
 	max_completion_tokens?: number;

--- a/src/llm.ts
+++ b/src/llm.ts
@@ -3,7 +3,6 @@
  */
 
 import {
-	complete,
 	getSupportedThinkingLevels,
 	type Api,
 	type AssistantMessage,
@@ -14,6 +13,7 @@ import {
 	type ToolResultMessage,
 	type ThinkingLevel,
 } from "@earendil-works/pi-ai";
+import { complete } from "@earendil-works/pi-ai/compat";
 import type { ExtensionContext, ModelRegistry } from "@earendil-works/pi-coding-agent";
 import { TOOL_OUTPUT_MAX_BYTES } from "./config.ts";
 import { modelDisplay } from "./models.ts";


### PR DESCRIPTION
## Summary

Pi users can now select `max` for panel and judge reasoning through Fusion configuration and `/fusion-setup`; previously, Fusion rejected a level that Pi itself supports.

Fusion still checks each resolved model before dispatch: models advertising `max` receive it, while lower-ceiling models run without the requested level and keep the existing non-fatal warning. The invoking model still cannot override reasoning through the `fusion` tool.

Supporting the same contract at runtime moves the documented Pi minimum to 0.80.6 and uses Pi's compatibility completion entrypoint, without expanding dependencies or starting the broader provider-runtime migration.

This PR prepares version 0.8.2; pushing `v0.8.2` after merge triggers the automated npm and GitHub release workflow.

Session-settled decisions carried from planning: retain one Fusion-owned ordered reasoning vocabulary (user-approved over a synchronization abstraction), preserve warn-without-clamping dispatch, and keep reasoning user-owned.

## Validation

- Full test suite, standard type check, and strict unused-code type check passed.
- Exact Pi 0.80.6 and current Pi 0.82.1 disposable-install matrices each passed the full suite and both type checks.
- Package metadata inspection and `npm pack --dry-run` passed for `pi-fusion@0.8.2`, with no runtime dependencies or test leakage.
- Six-lens code review completed with no actionable findings.
- Upgraded global Pi from 0.79.4 to 0.82.1, loaded only this checkout with `pi -ne -e .`, and verified `/fusion-setup` cycles both panel and judge reasoning from `xhigh` to `max`.

## Post-Deploy Monitoring & Validation

- During the first release/session smoke, search extension output for `Reasoning max is not supported`; verify supported models receive `max`, unsupported models warn once and continue, and both setup rows expose `max`.
- No dedicated dashboard exists for this local extension path; watch extension-load failures and provider completion errors in the active Pi session.
- Treat extension-load errors on Pi 0.80.6+ or provider reasoning failures as rollback triggers.
- Roll back by reverting this change or using the previous pi-fusion release with reasoning capped at `xhigh`; the maintainer owns the first-release check.

Fixes #19

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
