### PR TITLE
fix: forced mode, compact tool result, and recent-context dump skip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,7 @@ params, so the invoking model can't pick them. Effective precedence: session sel
 
 **Session state.** There is no key/value store: state is appended as custom session entries via
 `pi.appendEntry("fusion-state", …)` and read back by scanning `ctx.sessionManager.getBranch()`
-(`restoreSessionState`). The footer and `/fusion-status` derive from `effectiveDisplayState`
+(`restoreSessionState`). The footer, `/fusion-status`, `/fusion on`, forced input, and session options derive from `effectivePanel`
 (session → falls back to `fusion.json`). Modes (`available`/`forced`/`off`) live in that state.
 
 **Panel tools (multi-turn).** `tools.ts` builds tool definitions only from pi's hard-coded

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- `/fusion on` (and the bare toggle into forced) now uses the already-resolved panel from `fusion.json` / `defaultPanel` when the session has no `/fusion-setup` snapshot.
+- The `fusion` tool result returns analysis plus short excerpts instead of every full panel answer. Full panel text remains on `/fusion-report`. Unparseable or failed judge output is surfaced as a warning and `failure_reason` instead of a silent missing analysis.
+- `context_mode=recent` skips prior fusion-state entries, fusion tool-result JSON, and assistant blobs that are fusion details so panelists are not rebroadcast the last dump.
+
 ## 0.9.0
 
 - Resolved the `brace-expansion` and `protobufjs` denial-of-service advisories in the development dependency tree by pinning their patched transitive releases.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## Unreleased
 
-- `/fusion on` (and the bare toggle into forced) now uses the already-resolved panel from `fusion.json` / `defaultPanel` when the session has no `/fusion-setup` snapshot.
-- The `fusion` tool result returns analysis plus short excerpts instead of every full panel answer. Full panel text remains on `/fusion-report`. Unparseable or failed judge output is surfaced as a warning and `failure_reason` instead of a silent missing analysis.
+- `/fusion on` (and the bare toggle into forced) now uses the already-resolved panel from `fusion.json` / `defaultPanel` when the session has no `/fusion-setup` snapshot. Forced mode writes `mode` only; config stays the panel source until `/fusion-setup`.
+- The `fusion` tool result returns analysis plus short excerpts instead of every full panel answer. A single unjudged panel response is still returned in full. Full multi-panel text remains on `/fusion-report`. Unparseable or failed judge output is surfaced as a warning and `failure_reason` instead of a silent missing analysis. Empty/`{foo:1}` judge objects are not treated as analysis.
 - `context_mode=recent` skips prior fusion-state entries, fusion tool-result JSON, and assistant blobs that are fusion details so panelists are not rebroadcast the last dump.
 
 ## 0.9.0

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When the `fusion` tool runs, pi:
    - **partial_coverage**: points only some models raised
    - **unique_insights**: ideas raised by a single model
    - **blind_spots**: topics no panel model addressed
-4. Your active model receives the analysis plus short excerpts of each panel answer and writes the final answer. Full panel/judge text stays in `/fusion-report`.
+4. Your active model receives the analysis plus short excerpts of each panel answer and writes the final answer. If only one panel model succeeds, that full response is returned directly. Full multi-panel text stays in `/fusion-report`.
 
 When two or more panel models answer, the judge synthesis runs. If only one model succeeds, the single response is returned directly (no synthesis).
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ When the `fusion` tool runs, pi:
    - **partial_coverage**: points only some models raised
    - **unique_insights**: ideas raised by a single model
    - **blind_spots**: topics no panel model addressed
-4. Your active model receives the analysis plus the raw responses and writes the final answer.
+4. Your active model receives the analysis plus short excerpts of each panel answer and writes the final answer. Full panel/judge text stays in `/fusion-report`.
 
 When two or more panel models answer, the judge synthesis runs. If only one model succeeds, the single response is returned directly (no synthesis).
 
@@ -79,7 +79,7 @@ Use fusion to evaluate whether we should migrate to the Next.js App Router.
 ### Session modes
 
 ```
-/fusion on        # force every prompt through fusion (alias: forced); needs a panel from /fusion-setup
+/fusion on        # force every prompt through fusion (alias: forced); uses the session, fusion.json, or defaultPanel
 /fusion available # enable fusion; the model decides when to use it (alias: auto)
 /fusion off       # disable fusion and block fusion tool calls for the session (alias: disable)
 /fusion           # no argument: toggle between available and forced
@@ -112,7 +112,7 @@ Panel and judge calls do **not** see the whole pi conversation thread. When prio
 }
 ```
 
-`context_mode` defaults to `"none"`. `context_turns` is clamped to 1–10 (default 4). The judge sees the same context-expanded task the panel saw, plus the panel responses.
+`context_mode` defaults to `"none"`. `context_turns` is clamped to 1–10 (default 4). The judge sees the same context-expanded task the panel saw, plus the panel responses. Recent context skips prior fusion-state entries, fusion tool results, and assistant messages that are fusion details so those dumps are not sent to every panelist again.
 
 ## Configuration
 
@@ -223,7 +223,7 @@ Yes. `/fusion-setup` and the stateful `/fusion --panel` form are interactive-onl
 
 **How do I see what the panel and judge actually said?**
 
-`/fusion-report [--panel <name>] <prompt>` runs fusion directly and writes the raw panel/judge diagnostic report into the editor.
+`/fusion-report [--panel <name>] <prompt>` runs fusion directly and writes the raw panel/judge diagnostic report into the editor. The `fusion` tool result itself returns analysis plus short excerpts so later turns do not re-pay the full panel dump.
 
 ## Commands
 

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -45,6 +45,47 @@ test("buildRecentContextFromEntries skips tool messages", () => {
 	if (context.includes("tool output")) throw new Error("did not expect tool output");
 });
 
+test("buildRecentContextFromEntries skips prior fusion dumps", () => {
+	const dump = JSON.stringify({
+		status: "ok",
+		analysis: { consensus: ["secret-consensus"], contradictions: [], partial_coverage: [], unique_insights: [], blind_spots: [] },
+		responses: [{ model: "a/m", content: "full-panel-answer-should-not-rebroadcast" }],
+		panel_models: ["a/m"],
+	});
+	const compactDump = JSON.stringify({
+		status: "ok",
+		excerpts: [{ model: "a/m", excerpt: "excerpt-should-not-rebroadcast" }],
+		panel_models: ["a/m"],
+	});
+	const entries = [
+		msg("user", "u1"),
+		msg("assistant", dump),
+		{
+			type: "custom",
+			customType: "fusion-state",
+			data: { selectedIds: ["a/m"] },
+		},
+		{
+			type: "message",
+			message: {
+				role: "toolResult",
+				toolName: "fusion",
+				content: [{ type: "text", text: compactDump }],
+			},
+		},
+		msg("user", "u2"),
+		msg("assistant", "normal reply"),
+	];
+	const context = buildRecentContextFromEntries(entries, 2);
+	if (!context) throw new Error("expected context");
+	if (context.includes("secret-consensus")) throw new Error("did not expect analysis dump");
+	if (context.includes("full-panel-answer-should-not-rebroadcast")) throw new Error("did not expect full panel dump");
+	if (context.includes("excerpt-should-not-rebroadcast")) throw new Error("did not expect compact tool dump");
+	if (context.includes("a/m")) throw new Error("did not expect fusion-state ids");
+	if (!context.includes("User: u1") || !context.includes("User: u2")) throw new Error("expected real user turns");
+	if (!context.includes("Assistant: normal reply")) throw new Error("expected non-dump assistant reply");
+});
+
 test("buildFusionTaskText wraps context and current task", () => {
 	const task = buildFusionTaskText("Decide", "User: prior");
 	if (!task.includes("Recent conversation context:")) throw new Error("missing context heading");

--- a/src/__tests__/context.test.ts
+++ b/src/__tests__/context.test.ts
@@ -86,6 +86,13 @@ test("buildRecentContextFromEntries skips prior fusion dumps", () => {
 	if (!context.includes("Assistant: normal reply")) throw new Error("expected non-dump assistant reply");
 });
 
+test("buildRecentContextFromEntries keeps a reply that only quotes analysis JSON", () => {
+	const quoted = 'Example shape: {"status":"ok","analysis":{"consensus":["quoted-example"]}}';
+	const context = buildRecentContextFromEntries([msg("user", "u1"), msg("assistant", quoted)], 1);
+	if (!context) throw new Error("expected context");
+	if (!context.includes("quoted-example")) throw new Error("quoted analysis example should not drop the turn");
+});
+
 test("buildFusionTaskText wraps context and current task", () => {
 	const task = buildFusionTaskText("Decide", "User: prior");
 	if (!task.includes("Recent conversation context:")) throw new Error("missing context heading");

--- a/src/__tests__/fusion.test.ts
+++ b/src/__tests__/fusion.test.ts
@@ -22,6 +22,9 @@ test("parseFusionAnalysis defaults missing arrays to empty", () => {
 	}, "missing arrays default to []");
 	eq(parseFusionAnalysis("not an object"), undefined, "non-object is unparseable");
 	eq(parseFusionAnalysis(undefined), undefined, "missing JSON is unparseable");
+	eq(parseFusionAnalysis({}), undefined, "empty object is not analysis");
+	eq(parseFusionAnalysis({ foo: 1 }), undefined, "unrelated object is not analysis");
+	eq(parseFusionAnalysis({ consensus: "string" }), undefined, "non-array analysis key is not analysis");
 });
 
 test("compactFusionToolText returns analysis plus excerpts, not full panel text", () => {
@@ -37,6 +40,17 @@ test("compactFusionToolText returns analysis plus excerpts, not full panel text"
 	if (!text.includes("excerpts")) throw new Error("expected excerpts key");
 	if (text.includes(long)) throw new Error("tool result must not include full panel answer");
 	if (!text.includes("…")) throw new Error("expected truncated excerpt");
+});
+
+test("compactFusionToolText passes through a lone unjudged panel response", () => {
+	const long = "PANEL-FULL-".repeat(80);
+	const text = compactFusionToolText({
+		status: "ok",
+		responses: [{ model: "a/m", content: long }],
+		panel_models: ["a/m"],
+		judge_model: "a/j",
+	});
+	if (!text.includes(long)) throw new Error("single unjudged response must be returned in full");
 });
 
 test("emptyPanelError treats non-empty content as success", () => {
@@ -337,6 +351,9 @@ test("single panel success skips unsupported max judge without warning", async (
 		eq(seen, ["panel"], "judge provider is never called");
 		eq(result.details.judge_reasoning, undefined, "skipped judge has no reasoning diagnostics");
 		eq(result.details.warnings, undefined, "skipped unsupported judge does not warn");
+		if (!result.content[0]?.text.includes("only panel answer")) {
+			throw new Error("single unjudged panel answer must pass through the tool result");
+		}
 	} finally {
 		registration.unregister();
 		rmSync(cwd, { recursive: true, force: true });

--- a/src/__tests__/fusion.test.ts
+++ b/src/__tests__/fusion.test.ts
@@ -7,9 +7,37 @@ import { registerFauxProvider } from "@earendil-works/pi-ai/compat";
 import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { emptyPanelError, resolveFusionSelection, resolvePanelReasoning, runFusion } from "../fusion.ts";
+import { compactFusionToolText, emptyPanelError, parseFusionAnalysis, resolveFusionSelection, resolvePanelReasoning, runFusion } from "../fusion.ts";
 import type { Api, Model, ThinkingLevel } from "../types.ts";
 import { eq, fakeModel, test } from "./_harness.ts";
+
+test("parseFusionAnalysis defaults missing arrays to empty", () => {
+	const parsed = parseFusionAnalysis({ consensus: ["agreed"] });
+	eq(parsed, {
+		consensus: ["agreed"],
+		contradictions: [],
+		partial_coverage: [],
+		unique_insights: [],
+		blind_spots: [],
+	}, "missing arrays default to []");
+	eq(parseFusionAnalysis("not an object"), undefined, "non-object is unparseable");
+	eq(parseFusionAnalysis(undefined), undefined, "missing JSON is unparseable");
+});
+
+test("compactFusionToolText returns analysis plus excerpts, not full panel text", () => {
+	const long = "PANEL-FULL-".repeat(80);
+	const text = compactFusionToolText({
+		status: "ok",
+		analysis: { consensus: ["agreed"], contradictions: [], partial_coverage: [], unique_insights: [], blind_spots: [] },
+		responses: [{ model: "a/m", content: long }],
+		panel_models: ["a/m"],
+		judge_model: "a/j",
+	});
+	if (!text.includes("agreed")) throw new Error("expected analysis in tool result");
+	if (!text.includes("excerpts")) throw new Error("expected excerpts key");
+	if (text.includes(long)) throw new Error("tool result must not include full panel answer");
+	if (!text.includes("…")) throw new Error("expected truncated excerpt");
+});
 
 test("emptyPanelError treats non-empty content as success", () => {
 	eq(emptyPanelError("a real answer", false), undefined, "normal");
@@ -309,6 +337,68 @@ test("single panel success skips unsupported max judge without warning", async (
 		eq(seen, ["panel"], "judge provider is never called");
 		eq(result.details.judge_reasoning, undefined, "skipped judge has no reasoning diagnostics");
 		eq(result.details.warnings, undefined, "skipped unsupported judge does not warn");
+	} finally {
+		registration.unregister();
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("runFusion surfaces judge JSON failure instead of silent ok analysis", async () => {
+	const unique = Math.random().toString(36).slice(2);
+	const provider = `fusion-judge-fail-${unique}`;
+	const registration = registerFauxProvider({
+		api: `fusion-judge-fail-api-${unique}`,
+		provider,
+		models: [
+			{ id: "panel-a" },
+			{ id: "panel-b" },
+			{ id: "judge" },
+		],
+	});
+	const panelA = registration.getModel("panel-a") as Model<Api>;
+	const panelB = registration.getModel("panel-b") as Model<Api>;
+	const judge = registration.getModel("judge") as Model<Api>;
+	registration.setResponses([
+		() => fauxAssistantMessage("first panel answer that is long enough to be excerpted in the tool result"),
+		() => fauxAssistantMessage("second panel answer that is long enough to be excerpted in the tool result"),
+		() => fauxAssistantMessage("the judge said words but not JSON"),
+	]);
+
+	const cwd = trustedProjectConfig();
+	const registry = {
+		...registryFor([panelA, panelB, judge]),
+		async getApiKeyAndHeaders() {
+			return { ok: true, apiKey: "test" };
+		},
+	} as any;
+
+	try {
+		const result = await runFusion(
+			cwd,
+			registry,
+			undefined,
+			"compare",
+			true,
+			{
+				analysis_models: [`${provider}/panel-a`, `${provider}/panel-b`],
+				model: `${provider}/judge`,
+			},
+			{} as any,
+			false,
+			undefined,
+		);
+
+		eq(result.details.status, "ok", "panel success is still ok");
+		eq(result.details.analysis, undefined, "unparseable judge has no analysis");
+		eq(result.details.failure_reason, "unexpected_error", "judge failure is classified");
+		if (!result.details.warnings?.some((w) => w.includes("unparseable"))) {
+			throw new Error(`expected unparseable warning: ${result.details.warnings?.join("; ")}`);
+		}
+		const toolText = result.content[0]?.text ?? "";
+		if (/"responses"\s*:/.test(toolText)) throw new Error("tool result should use excerpts, not full responses");
+		if (!toolText.includes("excerpts")) throw new Error("expected excerpts in tool result");
+		if (!toolText.includes("failure_reason")) throw new Error("tool result should surface failure_reason");
+		eq(result.details.responses.length, 2, "details still keep full panel answers for /fusion-report");
 	} finally {
 		registration.unregister();
 		rmSync(cwd, { recursive: true, force: true });

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -11,7 +11,6 @@ import registerFusionExtension, {
 	fusionFooterText,
 	normalizeFooterDisplay,
 	parsePanelCommand,
-	resolveModeCommandPanel,
 } from "../index.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PendingPanelSelection } from "../index.ts";
@@ -120,10 +119,55 @@ test("/fusion on uses fusion.json / defaultPanel when session has no selectedIds
 			throw new Error(`forced mode rejected config panel: ${logs.join(" | ")}`);
 		}
 		eq(persisted?.mode, "forced", "persisted forced mode");
-		eq(persisted?.selectedIds, ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"], "persisted defaultPanel");
-		eq(persisted?.judgeId, "anthropic/claude-opus-4-5", "persisted defaultPanel judge");
+		eq(persisted?.selectedIds, [], "config stays the panel source until /fusion-setup");
+		if (!logs.some((line) => line.includes("Fusion forced") && line.includes("2 panel"))) {
+			throw new Error(`expected forced footer from defaultPanel: ${logs.join(" | ")}`);
+		}
 	} finally {
 		console.log = orig;
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
+test("forced input uses fusion.json when session stored mode only", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fusion-input-"));
+	mkdirSync(join(cwd, ".pi"));
+	writeFileSync(join(cwd, ".pi", "fusion.json"), JSON.stringify({
+		panel: ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"],
+		judge: "anthropic/claude-opus-4-5",
+	}));
+
+	type EventHandler = (event: unknown, ctx: unknown) => unknown | Promise<unknown>;
+	const handlers = new Map<string, EventHandler>();
+	registerFusionExtension({
+		registerTool() {},
+		registerCommand() {},
+		on(event: string, handler: EventHandler) {
+			handlers.set(event, handler);
+		},
+		getThinkingLevel: () => "off",
+	} as never);
+
+	try {
+		const input = handlers.get("input");
+		if (!input) throw new Error("expected input handler");
+		const result = await input(
+			{ source: "user", text: "hello", images: undefined },
+			{
+				cwd,
+				isProjectTrusted: () => true,
+				sessionManager: {
+					getBranch: () => [{
+						type: "custom",
+						customType: "fusion-state",
+						data: { selectedIds: [], mode: "forced" },
+					}],
+				},
+				ui: { setStatus() {} },
+			},
+		);
+		eq((result as { action?: string }).action, "transform", "forced mode with config panel transforms input");
+	} finally {
 		rmSync(cwd, { recursive: true, force: true });
 	}
 });
@@ -169,19 +213,6 @@ test("fusionFooterText supports full, compact, and off display modes", () => {
 test("fusionFooterText hides footer text when panel is empty", () => {
 	eq(fusionFooterText(new Set(), undefined, "available", "full"), undefined, "available mode with no panel hides text");
 	eq(fusionFooterText(new Set(), undefined, "off", "full"), "Fusion off", "off mode still reports disabled state");
-});
-
-test("resolveModeCommandPanel uses config / defaultPanel when session has no snapshot", () => {
-	const config = { selectedIds: new Set(["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"]), judgeId: "anthropic/claude-opus-4-5" };
-	const fromConfig = resolveModeCommandPanel({ selectedIds: new Set(), judgeId: undefined }, config);
-	eq(fromConfig?.judgeId, "anthropic/claude-opus-4-5", "config judge used");
-	eq([...(fromConfig?.selectedIds ?? [])], ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"], "config panel used");
-
-	const session = { selectedIds: new Set(["session/panel"]), judgeId: "session/judge" };
-	const fromSession = resolveModeCommandPanel(session, config);
-	eq([...(fromSession?.selectedIds ?? [])], ["session/panel"], "session snapshot wins when present");
-
-	eq(resolveModeCommandPanel({ selectedIds: new Set(), judgeId: undefined }, { selectedIds: new Set(), judgeId: undefined }), undefined, "empty session and config cannot arm forced");
 });
 
 function fakeContext(branch: unknown[] = []): ExtensionContext {

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { test, eq, fakeModel } from "./_harness.ts";
 import registerFusionExtension, {
 	activatePendingPanel,
@@ -8,6 +11,7 @@ import registerFusionExtension, {
 	fusionFooterText,
 	normalizeFooterDisplay,
 	parsePanelCommand,
+	resolveModeCommandPanel,
 } from "../index.ts";
 import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
 import type { PendingPanelSelection } from "../index.ts";
@@ -70,6 +74,60 @@ test("fusion tool schema exposes only prompt and context controls", () => {
 	);
 });
 
+test("/fusion on uses fusion.json / defaultPanel when session has no selectedIds", async () => {
+	const cwd = mkdtempSync(join(tmpdir(), "pi-fusion-on-"));
+	mkdirSync(join(cwd, ".pi"));
+	writeFileSync(join(cwd, ".pi", "fusion.json"), JSON.stringify({
+		defaultPanel: "quality",
+		panels: {
+			quality: {
+				models: ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"],
+				judge: "anthropic/claude-opus-4-5",
+			},
+		},
+	}));
+
+	const commands = new Map<string, { handler: (args: string, ctx: unknown) => Promise<void> }>();
+	let persisted: { selectedIds?: string[]; mode?: string; judgeId?: string } | undefined;
+	registerFusionExtension({
+		registerTool() {},
+		registerCommand(name: string, spec: { handler: (args: string, ctx: unknown) => Promise<void> }) {
+			commands.set(name, spec);
+		},
+		on() {},
+		appendEntry(_type: string, data: { selectedIds?: string[]; mode?: string; judgeId?: string }) {
+			persisted = data;
+		},
+		getThinkingLevel: () => "off",
+	} as never);
+
+	const logs: string[] = [];
+	const orig = console.log;
+	console.log = (msg?: unknown) => {
+		logs.push(String(msg ?? ""));
+	};
+	try {
+		const handler = commands.get("fusion")?.handler;
+		if (!handler) throw new Error("expected /fusion command");
+		await handler("on", {
+			cwd,
+			isProjectTrusted: () => true,
+			mode: "print",
+			sessionManager: { getBranch: () => [] },
+			ui: { notify() {}, setStatus() {} },
+		});
+		if (logs.some((line) => line.includes("No fusion setup"))) {
+			throw new Error(`forced mode rejected config panel: ${logs.join(" | ")}`);
+		}
+		eq(persisted?.mode, "forced", "persisted forced mode");
+		eq(persisted?.selectedIds, ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"], "persisted defaultPanel");
+		eq(persisted?.judgeId, "anthropic/claude-opus-4-5", "persisted defaultPanel judge");
+	} finally {
+		console.log = orig;
+		rmSync(cwd, { recursive: true, force: true });
+	}
+});
+
 test("pending panel is session-bound, agent-bound, and consumed once", () => {
 	let pending: PendingPanelSelection | undefined = armPendingPanel("fast", "session-a");
 	eq(consumePendingPanel(pending, "session-a"), { panelName: undefined, pending }, "not consumed before agent start");
@@ -111,6 +169,19 @@ test("fusionFooterText supports full, compact, and off display modes", () => {
 test("fusionFooterText hides footer text when panel is empty", () => {
 	eq(fusionFooterText(new Set(), undefined, "available", "full"), undefined, "available mode with no panel hides text");
 	eq(fusionFooterText(new Set(), undefined, "off", "full"), "Fusion off", "off mode still reports disabled state");
+});
+
+test("resolveModeCommandPanel uses config / defaultPanel when session has no snapshot", () => {
+	const config = { selectedIds: new Set(["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"]), judgeId: "anthropic/claude-opus-4-5" };
+	const fromConfig = resolveModeCommandPanel({ selectedIds: new Set(), judgeId: undefined }, config);
+	eq(fromConfig?.judgeId, "anthropic/claude-opus-4-5", "config judge used");
+	eq([...(fromConfig?.selectedIds ?? [])], ["openai/gpt-4.1", "anthropic/claude-sonnet-4-5"], "config panel used");
+
+	const session = { selectedIds: new Set(["session/panel"]), judgeId: "session/judge" };
+	const fromSession = resolveModeCommandPanel(session, config);
+	eq([...(fromSession?.selectedIds ?? [])], ["session/panel"], "session snapshot wins when present");
+
+	eq(resolveModeCommandPanel({ selectedIds: new Set(), judgeId: undefined }, { selectedIds: new Set(), judgeId: undefined }), undefined, "empty session and config cannot arm forced");
 });
 
 function fakeContext(branch: unknown[] = []): ExtensionContext {

--- a/src/context.ts
+++ b/src/context.ts
@@ -2,11 +2,29 @@
  * Conversation-context helpers for optional fusion context.
  */
 
+import { extractJson } from "./utils.ts";
+
 const MAX_CONTEXT_TURNS = 10;
 const DEFAULT_CONTEXT_TURNS = 4;
 const MAX_CONTEXT_CHARS = 20000;
 
 export type FusionContextMode = "none" | "recent";
+
+/** Prior fusion-state, tool-result JSON, or assistant blobs that are fusion details. */
+export function isFusionDumpText(text: string): boolean {
+	const parsed = extractJson<Record<string, unknown>>(text);
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
+	if (parsed.status !== "ok" && parsed.status !== "error") return false;
+	return "responses" in parsed || "excerpts" in parsed || "analysis" in parsed || "panel_models" in parsed;
+}
+
+function isFusionDumpEntry(entry: { type?: unknown; customType?: unknown; message?: { role?: unknown; toolName?: unknown } }): boolean {
+	if (entry.customType === "fusion-state") return true;
+	const role = entry.message?.role;
+	if (role === "toolResult" || role === "tool") return true;
+	if (entry.message?.toolName === "fusion") return true;
+	return false;
+}
 
 export function normalizeContextTurns(value: number | undefined): number {
 	if (value === undefined || !Number.isFinite(value)) return DEFAULT_CONTEXT_TURNS;
@@ -36,12 +54,13 @@ export function buildRecentContextFromEntries(entries: unknown[], turns: number 
 	let userMessagesSeen = 0;
 
 	for (let i = entries.length - 1; i >= 0; i--) {
-		const entry = entries[i] as { type?: unknown; message?: { role?: unknown } };
+		const entry = entries[i] as { type?: unknown; customType?: unknown; message?: { role?: unknown; toolName?: unknown } };
+		if (isFusionDumpEntry(entry)) continue;
 		if (entry?.type !== "message" || !entry.message) continue;
 		const role = entry.message.role;
 		if (role !== "user" && role !== "assistant") continue;
 		const text = extractMessageText(entry.message);
-		if (!text) continue;
+		if (!text || isFusionDumpText(text)) continue;
 		messages.unshift({ role, text });
 		if (role === "user") {
 			userMessagesSeen++;

--- a/src/context.ts
+++ b/src/context.ts
@@ -10,20 +10,16 @@ const MAX_CONTEXT_CHARS = 20000;
 
 export type FusionContextMode = "none" | "recent";
 
-/** Prior fusion-state, tool-result JSON, or assistant blobs that are fusion details. */
+/** Prior fusion-state or a dump that has panel bodies plus panel_models. */
 export function isFusionDumpText(text: string): boolean {
 	const parsed = extractJson<Record<string, unknown>>(text);
 	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) return false;
 	if (parsed.status !== "ok" && parsed.status !== "error") return false;
-	return "responses" in parsed || "excerpts" in parsed || "analysis" in parsed || "panel_models" in parsed;
+	return ("responses" in parsed || "excerpts" in parsed) && "panel_models" in parsed;
 }
 
-function isFusionDumpEntry(entry: { type?: unknown; customType?: unknown; message?: { role?: unknown; toolName?: unknown } }): boolean {
-	if (entry.customType === "fusion-state") return true;
-	const role = entry.message?.role;
-	if (role === "toolResult" || role === "tool") return true;
-	if (entry.message?.toolName === "fusion") return true;
-	return false;
+function isFusionDumpEntry(entry: { customType?: unknown }): boolean {
+	return entry.customType === "fusion-state";
 }
 
 export function normalizeContextTurns(value: number | undefined): number {

--- a/src/fusion.ts
+++ b/src/fusion.ts
@@ -49,10 +49,13 @@ import type {
 /** Short excerpt budget for the tool result (full text stays on `details` for /fusion-report). */
 const TOOL_RESULT_EXCERPT_BYTES = 480;
 
+const ANALYSIS_KEYS = ["consensus", "contradictions", "partial_coverage", "unique_insights", "blind_spots"] as const;
+
 /** Accept judge JSON as FusionAnalysis; missing arrays default to []. */
 export function parseFusionAnalysis(value: unknown): FusionAnalysis | undefined {
 	if (value == null || typeof value !== "object" || Array.isArray(value)) return undefined;
 	const obj = value as Record<string, unknown>;
+	if (!ANALYSIS_KEYS.some((key) => Array.isArray(obj[key]))) return undefined;
 	return {
 		consensus: Array.isArray(obj.consensus) ? obj.consensus : [],
 		contradictions: Array.isArray(obj.contradictions) ? obj.contradictions : [],
@@ -64,13 +67,14 @@ export function parseFusionAnalysis(value: unknown): FusionAnalysis | undefined 
 
 /** Tool-visible payload: analysis + short excerpts. Full panel/judge text stays on `details`. */
 export function compactFusionToolText(details: FusionDetails): string {
+	const passThroughSingle = details.responses.length === 1 && !details.analysis;
 	return JSON.stringify(
 		{
 			status: details.status,
 			analysis: details.analysis,
 			excerpts: details.responses.map((r) => ({
 				model: r.model,
-				excerpt: truncateToBytes(r.content, TOOL_RESULT_EXCERPT_BYTES, "…"),
+				excerpt: passThroughSingle ? r.content : truncateToBytes(r.content, TOOL_RESULT_EXCERPT_BYTES, "…"),
 				...(r.tools ? { tools: r.tools } : {}),
 			})),
 			...(details.failed_models ? { failed_models: details.failed_models } : {}),

--- a/src/fusion.ts
+++ b/src/fusion.ts
@@ -33,7 +33,7 @@ import {
 	selectionLabel,
 	selectionToNames,
 } from "./tools.ts";
-import { extractJson, mapWithConcurrencyLimit } from "./utils.ts";
+import { extractJson, mapWithConcurrencyLimit, truncateToBytes } from "./utils.ts";
 import type {
 	FusionAnalysis,
 	FusionConfig,
@@ -45,6 +45,50 @@ import type {
 	ThinkingLevel,
 	ToolSelection,
 } from "./types.ts";
+
+/** Short excerpt budget for the tool result (full text stays on `details` for /fusion-report). */
+const TOOL_RESULT_EXCERPT_BYTES = 480;
+
+/** Accept judge JSON as FusionAnalysis; missing arrays default to []. */
+export function parseFusionAnalysis(value: unknown): FusionAnalysis | undefined {
+	if (value == null || typeof value !== "object" || Array.isArray(value)) return undefined;
+	const obj = value as Record<string, unknown>;
+	return {
+		consensus: Array.isArray(obj.consensus) ? obj.consensus : [],
+		contradictions: Array.isArray(obj.contradictions) ? obj.contradictions : [],
+		partial_coverage: Array.isArray(obj.partial_coverage) ? obj.partial_coverage : [],
+		unique_insights: Array.isArray(obj.unique_insights) ? obj.unique_insights : [],
+		blind_spots: Array.isArray(obj.blind_spots) ? obj.blind_spots : [],
+	};
+}
+
+/** Tool-visible payload: analysis + short excerpts. Full panel/judge text stays on `details`. */
+export function compactFusionToolText(details: FusionDetails): string {
+	return JSON.stringify(
+		{
+			status: details.status,
+			analysis: details.analysis,
+			excerpts: details.responses.map((r) => ({
+				model: r.model,
+				excerpt: truncateToBytes(r.content, TOOL_RESULT_EXCERPT_BYTES, "…"),
+				...(r.tools ? { tools: r.tools } : {}),
+			})),
+			...(details.failed_models ? { failed_models: details.failed_models } : {}),
+			panel_models: details.panel_models,
+			judge_model: details.judge_model,
+			...(details.panel_profile ? { panel_profile: details.panel_profile } : {}),
+			...(details.warnings ? { warnings: details.warnings } : {}),
+			...(details.error ? { error: details.error } : {}),
+			...(details.failure_reason ? { failure_reason: details.failure_reason } : {}),
+		},
+		null,
+		2,
+	);
+}
+
+function fusionToolResult(details: FusionDetails): FusionResult {
+	return { content: [{ type: "text", text: compactFusionToolText(details) }], details };
+}
 
 /**
  * Classify a panel's final text. Blank output (a model that gathered tools but never
@@ -184,7 +228,7 @@ function selectionFailure(message: string, profileName: string | undefined, warn
 		error: message,
 		failure_reason: "unexpected_error",
 	};
-	return { ok: false, result: { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details } };
+	return { ok: false, result: fusionToolResult(details) };
 }
 
 export async function resolveFusionModels(
@@ -321,7 +365,7 @@ export async function runFusion(
 			error: "all panel models failed",
 			failure_reason: classifyAllPanelFailure(failed),
 		};
-		return { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details };
+		return fusionToolResult(details);
 	}
 
 	onUpdate?.({
@@ -338,6 +382,7 @@ export async function runFusion(
 	});
 
 	let analysis: FusionAnalysis | undefined;
+	let judgeFailureReason: FusionDetails["failure_reason"];
 	let judgeReasoningDetails: FusionDetails["judge_reasoning"];
 	if (successful.length >= 2) {
 		const judgeReasoning = resolveModelReasoning(judge, requestedJudgeReasoning);
@@ -374,10 +419,15 @@ export async function runFusion(
 				judgeReasoning.effective,
 			);
 			const judgeText = getTextContent(judgeResponse);
-			analysis = extractJson<FusionAnalysis>(judgeText);
+			analysis = parseFusionAnalysis(extractJson(judgeText));
+			if (!analysis) {
+				warnings.push("Judge returned unparseable JSON; analysis is unavailable. Use /fusion-report for raw panel text.");
+				judgeFailureReason = "unexpected_error";
+			}
 		} catch (err) {
 			console.error("[pi-fusion] judge failed:", err);
-			analysis = undefined;
+			warnings.push("Judge call failed; analysis is unavailable. Use /fusion-report for raw panel text.");
+			judgeFailureReason = "unexpected_error";
 		}
 	}
 
@@ -397,9 +447,10 @@ export async function runFusion(
 			? { panel_tools: { mode: selectionLabel(toolSelection), max_tool_calls: maxToolCalls, serialized: mutating } }
 			: {}),
 		...(warnings.length > 0 ? { warnings } : {}),
+		...(judgeFailureReason ? { failure_reason: judgeFailureReason } : {}),
 	};
 
-	return { content: [{ type: "text", text: JSON.stringify(details, null, 2) }], details };
+	return fusionToolResult(details);
 }
 
 function classifyAllPanelFailure(failed: PanelResult[]): FusionDetails["failure_reason"] {

--- a/src/index.ts
+++ b/src/index.ts
@@ -247,13 +247,10 @@ function restoreSessionState(ctx: ExtensionContext): FusionSetupState | undefine
 }
 
 /**
- * What to show in the footer/status: the session selection if present, otherwise
- * the `fusion.json` config (so a configured panel shows without running /fusion-setup).
- * Returns undefined when nothing is configured at all.
+ * Panel from fusion.json / named defaultPanel. Used by the footer and by
+ * `/fusion on` so forced mode does not require a /fusion-setup session snapshot.
  */
-function effectiveDisplayState(ctx: ExtensionContext): FusionSetupState | undefined {
-	const session = restoreSessionState(ctx);
-	if (session?.selectedIds.size || normalizeMode(session) === "off") return session;
+function configFallbackState(ctx: ExtensionContext): FusionSetupState | undefined {
 	const cfg = loadConfig(ctx.cwd, ctx.isProjectTrusted());
 	const effective = resolveEffectiveConfig(cfg);
 	if (effective.ok && ((effective.config.panel && effective.config.panel.length > 0) || effective.config.judge)) {
@@ -269,7 +266,28 @@ function effectiveDisplayState(ctx: ExtensionContext): FusionSetupState | undefi
 			footerDisplay: normalizeFooterDisplay(effective.config.footerDisplay),
 		};
 	}
-	return session;
+	return undefined;
+}
+
+/**
+ * What to show in the footer/status: the session selection if present, otherwise
+ * the `fusion.json` config (so a configured panel shows without running /fusion-setup).
+ * Returns undefined when nothing is configured at all.
+ */
+function effectiveDisplayState(ctx: ExtensionContext): FusionSetupState | undefined {
+	const session = restoreSessionState(ctx);
+	if (session?.selectedIds.size || normalizeMode(session) === "off") return session;
+	return configFallbackState(ctx) ?? session;
+}
+
+/** Session snapshot wins; otherwise the already-resolved config / defaultPanel. */
+export function resolveModeCommandPanel(
+	session: Pick<FusionSetupState, "selectedIds" | "judgeId"> | undefined,
+	configPanel: Pick<FusionSetupState, "selectedIds" | "judgeId"> | undefined,
+): { selectedIds: Set<string>; judgeId: string | undefined } | undefined {
+	if (session?.selectedIds.size) return { selectedIds: session.selectedIds, judgeId: session.judgeId };
+	if (configPanel?.selectedIds.size) return { selectedIds: configPanel.selectedIds, judgeId: configPanel.judgeId };
+	return undefined;
 }
 
 function sessionFusionOptions(ctx: ExtensionContext): FusionOptions {
@@ -481,6 +499,8 @@ export default function (pi: ExtensionAPI) {
 			}
 			const prompt = parsed.prompt;
 			const sessionState = restoreSessionState(ctx);
+			const configState = configFallbackState(ctx);
+			const modePanel = resolveModeCommandPanel(sessionState, configState);
 			const lower = prompt.toLowerCase();
 			const modeCommand: FusionMode | undefined =
 				lower === "off" || lower === "disable" || lower === "disabled"
@@ -493,22 +513,22 @@ export default function (pi: ExtensionAPI) {
 
 			if (!prompt || modeCommand) {
 				pendingPanel = undefined;
-				if (!sessionState?.selectedIds.size && (modeCommand === "forced" || (!prompt && !modeCommand))) {
+				if (!modePanel && (modeCommand === "forced" || (!prompt && !modeCommand))) {
 					const message = "No fusion setup yet. Run /fusion-setup first, or use /fusion off to disable.";
 					if (ctx.mode === "print") console.log(message);
 					else ctx.ui.notify(message, "warning");
 					return;
 				}
 
-				const selectedIds = sessionState?.selectedIds ?? new Set<string>();
-				const judgeId = sessionState?.judgeId;
+				const selectedIds = modePanel?.selectedIds ?? sessionState?.selectedIds ?? new Set<string>();
+				const judgeId = modePanel?.judgeId ?? sessionState?.judgeId;
 				const currentMode = normalizeMode(sessionState);
 				const nextMode = modeCommand ?? (currentMode === "forced" ? "available" : "forced");
-				persistSessionState(pi, selectedIds, judgeId, nextMode, sessionState ?? {});
+				persistSessionState(pi, selectedIds, judgeId, nextMode, sessionState ?? configState ?? {});
 				updateStatus(ctx, selectedIds, judgeId, nextMode);
 				const footerDisplay = effectiveFooterDisplay(ctx);
 				const summaryBase = fusionFooterText(selectedIds, judgeId, nextMode, footerDisplay) ?? modeLabel(nextMode);
-				const summary = footerDisplay === "full" ? summaryBase + toolsSuffix(sessionState) : summaryBase;
+				const summary = footerDisplay === "full" ? summaryBase + toolsSuffix(sessionState ?? configState) : summaryBase;
 				if (ctx.mode === "print") console.log(summary);
 				else ctx.ui.notify(summary, "info");
 				return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -181,7 +181,7 @@ function updateStatus(
 	mode: FusionMode = "available",
 ) {
 	const footerDisplay = effectiveFooterDisplay(ctx);
-	const state = effectiveDisplayState(ctx);
+	const state = effectivePanel(ctx);
 	const baseText = fusionFooterText(selectedIds, judgeId, mode, footerDisplay, state);
 	const fusionText = baseText && footerDisplay === "full" ? baseText + toolsSuffix(state) : baseText;
 	ctx.ui.setStatus("fusion", fusionText);
@@ -270,28 +270,32 @@ function configFallbackState(ctx: ExtensionContext): FusionSetupState | undefine
 }
 
 /**
- * What to show in the footer/status: the session selection if present, otherwise
- * the `fusion.json` config (so a configured panel shows without running /fusion-setup).
- * Returns undefined when nothing is configured at all.
+ * Session snapshot if it has a panel; otherwise fusion.json / defaultPanel.
+ * Session mode (including forced with empty selectedIds) is preserved so
+ * `/fusion on` can write mode only and leave config as the panel source.
  */
-function effectiveDisplayState(ctx: ExtensionContext): FusionSetupState | undefined {
+function effectivePanel(ctx: ExtensionContext): FusionSetupState | undefined {
 	const session = restoreSessionState(ctx);
-	if (session?.selectedIds.size || normalizeMode(session) === "off") return session;
-	return configFallbackState(ctx) ?? session;
-}
-
-/** Session snapshot wins; otherwise the already-resolved config / defaultPanel. */
-export function resolveModeCommandPanel(
-	session: Pick<FusionSetupState, "selectedIds" | "judgeId"> | undefined,
-	configPanel: Pick<FusionSetupState, "selectedIds" | "judgeId"> | undefined,
-): { selectedIds: Set<string>; judgeId: string | undefined } | undefined {
-	if (session?.selectedIds.size) return { selectedIds: session.selectedIds, judgeId: session.judgeId };
-	if (configPanel?.selectedIds.size) return { selectedIds: configPanel.selectedIds, judgeId: configPanel.judgeId };
-	return undefined;
+	if (session?.selectedIds.size) return session;
+	const config = configFallbackState(ctx);
+	if (!config) return session;
+	if (!session) return config;
+	return {
+		...config,
+		mode: normalizeMode(session),
+		enabled: normalizeMode(session) === "forced",
+		panelTools: session.panelTools && session.panelTools !== "none" ? session.panelTools : config.panelTools,
+		maxToolCalls: session.maxToolCalls ?? config.maxToolCalls,
+		toolsConsented: session.toolsConsented,
+		footerDisplay: session.footerDisplay ?? config.footerDisplay,
+		panelReasoning: session.panelReasoning ?? config.panelReasoning,
+		judgeReasoning: session.judgeReasoning ?? config.judgeReasoning,
+	};
 }
 
 function sessionFusionOptions(ctx: ExtensionContext): FusionOptions {
 	const sessionState = restoreSessionState(ctx);
+	const panel = effectivePanel(ctx);
 	// Only contribute the session tool mode when it's an explicit non-"none" choice,
 	// so the default "none" doesn't mask a fusion.json panelTools setting.
 	const tools: FusionOptions = {
@@ -301,11 +305,12 @@ function sessionFusionOptions(ctx: ExtensionContext): FusionOptions {
 		panel_reasoning: sessionState?.panelReasoning,
 		judge_reasoning: sessionState?.judgeReasoning,
 	};
+	// Config/defaultPanel stay the runFusion source until /fusion-setup writes selectedIds.
 	if (!sessionState?.selectedIds.size) return tools;
 	return {
 		...tools,
-		analysis_models: Array.from(sessionState.selectedIds),
-		model: sessionState.judgeId ?? Array.from(sessionState.selectedIds)[0],
+		analysis_models: Array.from(panel?.selectedIds ?? sessionState.selectedIds),
+		model: panel?.judgeId ?? sessionState.judgeId ?? Array.from(sessionState.selectedIds)[0],
 	};
 }
 
@@ -499,8 +504,7 @@ export default function (pi: ExtensionAPI) {
 			}
 			const prompt = parsed.prompt;
 			const sessionState = restoreSessionState(ctx);
-			const configState = configFallbackState(ctx);
-			const modePanel = resolveModeCommandPanel(sessionState, configState);
+			const panel = effectivePanel(ctx);
 			const lower = prompt.toLowerCase();
 			const modeCommand: FusionMode | undefined =
 				lower === "off" || lower === "disable" || lower === "disabled"
@@ -513,22 +517,24 @@ export default function (pi: ExtensionAPI) {
 
 			if (!prompt || modeCommand) {
 				pendingPanel = undefined;
-				if (!modePanel && (modeCommand === "forced" || (!prompt && !modeCommand))) {
+				if (!panel?.selectedIds.size && (modeCommand === "forced" || (!prompt && !modeCommand))) {
 					const message = "No fusion setup yet. Run /fusion-setup first, or use /fusion off to disable.";
 					if (ctx.mode === "print") console.log(message);
 					else ctx.ui.notify(message, "warning");
 					return;
 				}
 
-				const selectedIds = modePanel?.selectedIds ?? sessionState?.selectedIds ?? new Set<string>();
-				const judgeId = modePanel?.judgeId ?? sessionState?.judgeId;
+				const selectedIds = sessionState?.selectedIds ?? new Set<string>();
+				const judgeId = sessionState?.judgeId;
 				const currentMode = normalizeMode(sessionState);
 				const nextMode = modeCommand ?? (currentMode === "forced" ? "available" : "forced");
-				persistSessionState(pi, selectedIds, judgeId, nextMode, sessionState ?? configState ?? {});
-				updateStatus(ctx, selectedIds, judgeId, nextMode);
+				persistSessionState(pi, selectedIds, judgeId, nextMode, sessionState ?? {});
+				const displayIds = panel?.selectedIds ?? selectedIds;
+				const displayJudge = panel?.judgeId ?? judgeId;
+				updateStatus(ctx, displayIds, displayJudge, nextMode);
 				const footerDisplay = effectiveFooterDisplay(ctx);
-				const summaryBase = fusionFooterText(selectedIds, judgeId, nextMode, footerDisplay) ?? modeLabel(nextMode);
-				const summary = footerDisplay === "full" ? summaryBase + toolsSuffix(sessionState ?? configState) : summaryBase;
+				const summaryBase = fusionFooterText(displayIds, displayJudge, nextMode, footerDisplay) ?? modeLabel(nextMode);
+				const summary = footerDisplay === "full" ? summaryBase + toolsSuffix(sessionState ?? panel) : summaryBase;
 				if (ctx.mode === "print") console.log(summary);
 				else ctx.ui.notify(summary, "info");
 				return;
@@ -767,7 +773,7 @@ export default function (pi: ExtensionAPI) {
 		description: "Show the current fusion mode, panel, and judge",
 		handler: async (_args, ctx) => {
 			const session = restoreSessionState(ctx);
-			const state = effectiveDisplayState(ctx);
+			const state = effectivePanel(ctx);
 			const fromConfig = !session?.selectedIds.size && !!state?.selectedIds.size;
 			const footerDisplay = effectiveFooterDisplay(ctx);
 			const lines: string[] = [];
@@ -806,8 +812,10 @@ export default function (pi: ExtensionAPI) {
 		if (event.text.trim().startsWith("/")) return { action: "continue" };
 		if (isFusionPrompt(event.text.trim())) return { action: "continue" };
 		const state = restoreSessionState(ctx);
-		if (normalizeMode(state) !== "forced" || !state?.selectedIds.size) return { action: "continue" };
-		updateStatus(ctx, state.selectedIds, state.judgeId, "forced");
+		if (normalizeMode(state) !== "forced") return { action: "continue" };
+		const panel = effectivePanel(ctx);
+		if (!panel?.selectedIds.size) return { action: "continue" };
+		updateStatus(ctx, panel.selectedIds, panel.judgeId, "forced");
 		return { action: "transform", text: forceFusionPrompt(event.text), images: event.images };
 	});
 
@@ -828,7 +836,7 @@ export default function (pi: ExtensionAPI) {
 	// Refresh Fusion's keyed status whenever the session/model changes (pi.on is overloaded per
 	// event name, so register the shared handler for each rather than looping).
 	const refreshFooter = (ctx: ExtensionContext) => {
-		const state = effectiveDisplayState(ctx);
+		const state = effectivePanel(ctx);
 		updateStatus(ctx, state?.selectedIds ?? new Set(), state?.judgeId, normalizeMode(state));
 	};
 	pi.on("session_start", async (_event, ctx) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Three targeted fixes only. Hypothesis verified against current code; Atomic QA notes on #22 addressed on the same branch.

## 1. `/fusion on` used only the session snapshot

`/fusion-status` already showed the live panel from `fusion.json` / named `defaultPanel`. `/fusion on` (and the bare toggle into forced) required `sessionState.selectedIds`.

Footer, `/fusion on`, forced input, and session options now share `effectivePanel`. `/fusion on` writes `mode: forced` only; config / `defaultPanel` stays the panel source until `/fusion-setup`. `resolveModeCommandPanel` and the config snapshot copy are gone.

## 2. Tool result replayed every full panel answer

The **tool result** is analysis + short excerpts on the judged path. A single unjudged panel response is returned in full (README). Full multi-panel text stays on `details` for `/fusion-report`.

Judge JSON is `FusionAnalysis` only when at least one of the five keys (`consensus`, `contradictions`, `partial_coverage`, `unique_insights`, `blind_spots`) is actually an array; missing arrays among those still default to `[]`. `{}`, `{foo:1}`, and `{consensus:"string"}` are unparseable and surface a warning + `failure_reason`.

## 3. `context_mode=recent` rebroadcast prior fusion dumps

Skips `customType: fusion-state` and text that has `status` plus **both** a body (`responses` or `excerpts`) **and** `panel_models`. A quoted `{status, analysis}` example in a normal reply is kept. Dead `tool`/`toolResult` branches next to the existing role filter were removed.

## Intentionally skipped (add later if needed)

- **Auto-only `/fusion on`** (no session snapshot and no `fusion.json` / `defaultPanel`). Status still says “not set up.” Add when someone wants forced mode with zero config, relying on runtime auto-select.
- **New `judge_failed` `failure_reason`.** Reused existing `unexpected_error`.
- **Configurable excerpt size.** Hardcoded 480 bytes on the judged path.
- **Deep judge-element shape checks.** Only “at least one of the five keys is an array”; item objects are not schema-validated.
- **Magic-shape cleanup beyond the dump pair.** Not done.
- **Unchanged on purpose:** hardcoded tool factories (fusion cannot recurse into the panel), tool schema still `prompt` / `context_mode` / `context_turns` only, mutating consent + serialize, project-trust gate on `.pi/fusion.json`, named panels themselves, no-silent-clamp reasoning.

## Testing

- [x] `npm test`
- [x] `npm run check`
- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9925947c-4db3-4b65-877a-622ce5321d80?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9925947c-4db3-4b65-877a-622ce5321d80&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

