### PR TITLE
chore: prepare v0.9.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 0.9.1
+
 - `/fusion on` (and the bare toggle into forced) now uses the already-resolved panel from `fusion.json` / `defaultPanel` when the session has no `/fusion-setup` snapshot. Forced mode writes `mode` only; config stays the panel source until `/fusion-setup`.
 - The `fusion` tool result returns analysis plus short excerpts instead of every full panel answer. A single unjudged panel response is still returned in full. Full multi-panel text remains on `/fusion-report`. Unparseable or failed judge output is surfaced as a warning and `failure_reason` instead of a silent missing analysis. Empty/`{foo:1}` judge objects are not treated as analysis.
 - `context_mode=recent` skips prior fusion-state entries, fusion tool-result JSON, and assistant blobs that are fusion details so panelists are not rebroadcast the last dump.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "pi-fusion",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pi-fusion",
-      "version": "0.9.0",
+      "version": "0.9.1",
       "license": "MIT",
       "devDependencies": {
         "jiti": "^2.4.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pi-fusion",
-  "version": "0.9.0",
+  "version": "0.9.1",
   "description": "Multi-model deliberation for pi, inspired by OpenRouter Fusion",
   "type": "module",
   "main": "./src/index.ts",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Patch release bump for 0.9.1 after #22 landed on main.

- `package.json` / `package-lock.json` version `0.9.0` → `0.9.1`
- CHANGELOG: `## Unreleased` renamed to `## 0.9.1`, empty `## Unreleased` added above

Release notes are the existing Unreleased bullets from #22. No other changes.

After this merges, tag `v0.9.1` on the main commit so `.github/workflows/release.yml` can publish to npm (OIDC) and create the GitHub Release.

## Testing

- [x] Diff is version + CHANGELOG heading only
- [ ] `npm run check` (unchanged source)
- [ ] `npm test` (unchanged source)
- [ ] Manual pi test, if UI/command behavior changed — N/A

## Checklist

- [x] I updated README/CHANGELOG for user-visible changes.
- [x] I kept the primary UX simple (`/fusion-setup`, `/fusion`, `/fusion <prompt>`, `/fusion-status`).
- [x] I did not add runtime dependencies unless necessary.
- [x] I considered privacy/context implications for panel and judge calls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-db15e25e-0a19-45be-9615-b4bd830957d6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-db15e25e-0a19-45be-9615-b4bd830957d6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

