### PR TITLE
Clarify that /fusion on needs a resolvable panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Clarified README and the `/fusion on` empty-panel message: forced mode needs a resolvable panel from `fusion.json` / `defaultPanel` / `/fusion-setup`, not auto-select.
+
 ## 0.9.1
 
 - `/fusion on` (and the bare toggle into forced) now uses the already-resolved panel from `fusion.json` / `defaultPanel` when the session has no `/fusion-setup` snapshot. Forced mode writes `mode` only; config stays the panel source until `/fusion-setup`.

--- a/README.md
+++ b/README.md
@@ -205,11 +205,11 @@ The prompt goes to every panel model and the judge, all models you're already au
 
 **Why didn't fusion run when I asked?**
 
-In `available` mode the model decides. If you want a guaranteed run, use `/fusion <prompt>` for one prompt or `/fusion on` for the session. Forced mode also needs at least one usable panel model, so check `/fusion-status`.
+In `available` mode the model decides. If you want a guaranteed run, use `/fusion <prompt>` for one prompt or `/fusion on` for the session. `/fusion on` needs a `/fusion-setup` snapshot, `fusion.json`, or `defaultPanel` (auto-select is not enough); `/fusion-status` says “not set up” until then.
 
 **Why did I get one model's answer with no analysis?**
 
-The judge synthesis only runs when **two or more** panel models succeed. If a single model answers (others failed or weren't authed), its response is returned directly.
+The judge synthesis only runs when **two or more** panel models succeed. If a single model answers (others failed or weren't authed), its response is returned directly. If two or more answered but the judge JSON failed, you get short excerpts and a warning; `/fusion-report` has the full text.
 
 **Which models get picked, and why was one skipped?**
 

--- a/README.md
+++ b/README.md
@@ -35,8 +35,6 @@ When the `fusion` tool runs, pi:
    - **blind_spots**: topics no panel model addressed
 4. Your active model receives the analysis plus short excerpts of each panel answer and writes the final answer. If only one panel model succeeds, that full response is returned directly. Full multi-panel text stays in `/fusion-report`.
 
-When two or more panel models answer, the judge synthesis runs. If only one model succeeds, the single response is returned directly (no synthesis).
-
 ## Install
 
 ```bash
@@ -59,7 +57,7 @@ There's no build step; pi loads the TypeScript directly via [jiti](https://githu
 Use fusion to compare REST vs GraphQL for a new public API.
 
 # 3. or force every prompt through fusion for the session
-/fusion on
+/fusion on   # needs fusion.json / defaultPanel / /fusion-setup; auto-select is not enough
 ```
 
 Check what's active any time with `/fusion-status`.
@@ -230,7 +228,7 @@ Yes. `/fusion-setup` and the stateful `/fusion --panel` form are interactive-onl
 | Command | What it does |
 |---------|--------------|
 | `/fusion-setup` | Load a named panel or customize a panel snapshot, judge, reasoning, tools, and Fusion status display (interactive mode only). |
-| `/fusion on` \| `available` \| `off` | Set the session mode (aliases: `forced`, `auto`, `disable`). |
+| `/fusion on` \| `available` \| `off` | Set the session mode (aliases: `forced`, `auto`, `disable`). `/fusion on` uses `fusion.json` / `defaultPanel` when there is no `/fusion-setup` snapshot. |
 | `/fusion` | With no argument, toggle between `available` and `forced`. |
 | `/fusion <prompt>` | Force fusion for a single prompt, then answer normally. |
 | `/fusion --panel <name> <prompt>` | Use a named panel for this interactive agent run only, then return to the prior selection. |

--- a/src/index.ts
+++ b/src/index.ts
@@ -518,7 +518,7 @@ export default function (pi: ExtensionAPI) {
 			if (!prompt || modeCommand) {
 				pendingPanel = undefined;
 				if (!panel?.selectedIds.size && (modeCommand === "forced" || (!prompt && !modeCommand))) {
-					const message = "No fusion setup yet. Run /fusion-setup first, or use /fusion off to disable.";
+					const message = "No fusion setup yet: configure fusion.json / defaultPanel, run /fusion-setup, or use /fusion off to disable.";
 					if (ctx.mode === "print") console.log(message);
 					else ctx.ui.notify(message, "warning");
 					return;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Small docs/copy pass so README and the `/fusion on` empty-panel message match the 0.9.1 behavior: forced mode needs a resolvable panel from `fusion.json` / `defaultPanel` / `/fusion-setup`. Auto-select is not enough.

- **What it does:** deleted the leftover paragraph that restated the single-success / no-synthesis path already covered by step 4.
- **Quick start:** one comment after `/fusion on` listing the resolvable-panel sources.
- **Commands table:** the `/fusion on | available | off` row now says `/fusion on` falls back to `fusion.json` / `defaultPanel` when there is no `/fusion-setup` snapshot.
- **`src/index.ts`:** the empty-panel warning is still one sentence and now mentions those same sources.
- **FAQ “Why didn't fusion run when I asked?”:** last sentence now says `/fusion on` needs a setup snapshot, `fusion.json`, or `defaultPanel` (not “a usable panel model”); `/fusion-status` says “not set up” until then.
- **FAQ “Why did I get one model's answer with no analysis?”:** if two or more answered but judge JSON failed, you get short excerpts and a warning; `/fusion-report` has the full text.

## Testing

- [x] `npm run check`
- [x] `npm test`
- [x] `npx tsc --noEmit --noUnusedLocals --noUnusedParameters`
- [ ] Manual pi test — copy-only; command behavior unchanged

## Checklist

- [x] I updated README/CHANGELOG for user-visible changes.
- [x] I kept the primary UX simple (`/fusion-setup`, `/fusion`, `/fusion <prompt>`, `/fusion-status`).
- [x] I did not add runtime dependencies unless necessary.
- [x] I considered privacy/context implications for panel and judge calls.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-19e1253f-3954-44d1-963b-2974da2689b6?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-19e1253f-3954-44d1-963b-2974da2689b6&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

